### PR TITLE
vdf: add `GmpClassGroup::is_valid()`

### DIFF
--- a/verifiable_delay/classgroup/src/gmp_classgroup/mod.rs
+++ b/verifiable_delay/classgroup/src/gmp_classgroup/mod.rs
@@ -69,6 +69,12 @@ impl GmpClassGroup {
         (self.a, self.b)
     }
 
+    pub fn is_valid(&self) -> bool {
+        let four: Mpz = 4u64.into();
+        let four_ac: Mpz = four * &self.a * &self.c;
+        &self.discriminant + four_ac == &self.b * &self.b
+    }
+
     fn inner_multiply(&mut self, rhs: &Self, ctx: &mut Ctx) {
         self.assert_valid();
         rhs.assert_valid();
@@ -187,9 +193,7 @@ impl GmpClassGroup {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn assert_valid(&self) {
         if cfg!(debug_assertions) {
-            let four: Mpz = 4u64.into();
-            let four_ac: Mpz = four * &self.a * &self.c;
-            assert!(&self.discriminant + four_ac == &self.b * &self.b);
+            assert!(self.is_valid());
         }
     }
 


### PR DESCRIPTION
This check can be used to avoid panicking in the case of an invalid class group.
