### PR TITLE
vdf: avoid panic when serializing

### DIFF
--- a/verifiable_delay/classgroup/src/gmp_classgroup/mod.rs
+++ b/verifiable_delay/classgroup/src/gmp_classgroup/mod.rs
@@ -402,9 +402,7 @@ impl ClassGroup for GmpClassGroup {
     }
 
     fn serialize(&self, buf: &mut [u8]) -> Result<(), usize> {
-        self.assert_valid();
-        if buf.len() & 1 == 1 {
-            // odd lengths do not make sense
+        if !self.is_valid() || buf.len() & 1 == 1 {
             Err(0)
         } else {
             let len = buf.len() >> 1;

--- a/verifiable_delay/vdf/src/proof_wesolowski.rs
+++ b/verifiable_delay/vdf/src/proof_wesolowski.rs
@@ -242,11 +242,9 @@ pub fn verify_proof<T: BigNum, V: ClassGroup<BigNum = T>>(
 ) -> Result<(), ()> {
     let element_len = 2 * ((int_size_bits + 16) >> 4);
     let mut x_buf = vec![0; element_len];
-    x.serialize(&mut x_buf[..])
-        .expect(super::INCORRECT_BUFFER_SIZE);
+    x.serialize(&mut x_buf[..]).map_err(|_| ())?;
     let mut y_buf = vec![0; element_len];
-    y.serialize(&mut y_buf[..])
-        .expect(super::INCORRECT_BUFFER_SIZE);
+    y.serialize(&mut y_buf[..]).map_err(|_| ())?;
     let b = hash_prime(&[&x_buf[..], &y_buf[..]]);
     let mut r = T::from(0);
     r.mod_powm(&T::from(2u64), &T::from(t), &b);


### PR DESCRIPTION
Perform an eager check that a value is valid prior to serialization, regardless of the optimization level, and return a `Result::Err`, which is propagated from the proof verifier.

This is sufficient to bubble the verification error up to here:

https://github.com/OLSF/libra/pull/27/files/9b2f62a99b69f3ab1ce016ca6127bd4680c81681..f9838c5d32f3565999d70007419fbcea03317e78#diff-836989e16df7980a88bc2a451520df8e