### PR TITLE
Proposal to remove panic

### DIFF
--- a/language/move-vm/natives/src/vdf.rs
+++ b/language/move-vm/natives/src/vdf.rs
@@ -46,7 +46,6 @@ pub fn verify(
     let result = panic::catch_unwind(|| {
         let r = v.verify(&challenge, difficulty, &alleged_solution);
         if r.is_err() {
-            // let return_values = vec![Value::bool(false)];
             return Err(());
         }
         Ok(())


### PR DESCRIPTION
Removes the panic on VDF failure and just returns Err(()). 

It's unclear why `panic::catch_unwind` isn't working.