### PR TITLE
Miner should start with latest waypoint

### DIFF
--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -42,7 +42,7 @@ impl MinerConfig {
             Ok(file) => {
                 let json: serde_json::Value = serde_json::from_reader(file)
                     .expect("could not parse JSON in key_store.json");
-                let value = ajson::get(&json.to_string(), "*waypoint.value").expect("could not find key: waypoint");
+                let value = ajson::get(&json.to_string(), "*/waypoint.value").expect("could not find key: waypoint");
                 dbg!(&value);
                 let waypoint: Waypoint = value.to_string().parse().unwrap();
                 Some(waypoint)

--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -42,7 +42,7 @@ impl MinerConfig {
             Ok(file) => {
                 let json: serde_json::Value = serde_json::from_reader(file)
                     .expect("could not parse JSON in key_store.json");
-                let value = ajson::get(&json.to_string(), "*/waypoint.value").expect("could not find key: waypoint");
+                let value = ajson::get(&json.to_string(), "*oper/waypoint.value").expect("could not find key: waypoint");
                 dbg!(&value);
                 let waypoint: Waypoint = value.to_string().parse().unwrap();
                 Some(waypoint)


### PR DESCRIPTION
- Miner reads waypoint from key_store.json. 
- Key Store has genesis-waypoint and oper-waypoint. The former is constant, while the later updates with time. 
- The miner should read the oper-waypoint for setting its configs