### PR TITLE
Fix broken macOS build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
+[target.'cfg(target_os = "linux")']
 # Dramatically increases the link performance for the eventbus
-[build]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [alias]


### PR DESCRIPTION
`lld` linker does not work on macOS currently. This fixes the broken macOS build.