### PR TITLE
Vscode devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/vscode/devcontainers/rust:1
+
+# Install extra packages specified in ../util/setup.sh
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends build-essential cmake clang llvm secure-delete lld

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,3 +3,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:1
 # Install extra packages specified in ../util/setup.sh
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends build-essential cmake clang llvm secure-delete lld
+
+USER vscode
+RUN cargo install toml-cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"rust-lang.rust",
+		"bungcip.better-toml",
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "cargo install toml-cli",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "cargo install toml-cli",
+	// "postCreateCommand": "",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"rust-lang.rust",
+		"matklad.rust-analyzer",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor"

--- a/.devcontainer/notes.md
+++ b/.devcontainer/notes.md
@@ -1,2 +1,1 @@
 We may need: `export NODE_ENV=prod` from setup.sh
-Need to figure out how to run : `cargo install toml-cli` automatically, without running into permission issues with the cargo cache.

--- a/.devcontainer/notes.md
+++ b/.devcontainer/notes.md
@@ -1,0 +1,2 @@
+We may need: `export NODE_ENV=prod` from setup.sh
+Need to figure out how to run : `cargo install toml-cli` automatically, without running into permission issues with the cargo cache.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ DATA_PATH = ${HOME}/.0L
 CHAIN_ID = 1
 
 ifndef SOURCE
-SOURCE=${HOME}/libra
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
+SOURCE=${MAKEFILE_DIR}
 endif
 
 ifndef V


### PR DESCRIPTION
Add support for building and editing using Microsoft's VSCode IDE with "devcontainer" docker container tailored to the required toolchain. Tested as far as confirming that `make bins` succeeds. 