### PR TITLE
Fullnodestate fixes

### DIFF
--- a/language/move-lang/functional-tests/tests/0L/cases/case_1_reconfig.move
+++ b/language/move-lang/functional-tests/tests/0L/cases/case_1_reconfig.move
@@ -104,6 +104,7 @@ script {
     use 0x1::NodeWeight;
     use 0x1::GAS::GAS;
     use 0x1::LibraAccount;
+    use 0x1::Debug::print;
 
     fun main(_account: &signer) {
         // We are in a new epoch.
@@ -111,7 +112,13 @@ script {
         // Check the validator set is at expected size
         assert(LibraSystem::validator_set_size() == 5, 7357000180110);
         assert(LibraSystem::is_validator({{alice}}) == true, 7357000180111);
-        assert(LibraAccount::balance<GAS>({{alice}}) == 295000001, 7357000180112);  
+        print(&LibraAccount::balance<GAS>({{alice}}));
+        
+        let starting_balance = 1;
+        let expected_subsidy = 295000000; //294978321
+        let operator_refund = 4336 * 5; // BASELINE_TX_COST * proofs = 21680
+        let ending_balance = starting_balance + expected_subsidy - operator_refund;
+        assert(LibraAccount::balance<GAS>({{alice}}) == ending_balance, 7357000180112);  
         assert(NodeWeight::proof_of_weight({{alice}}) == 1, 7357000180113);  
     }
 }

--- a/language/stdlib/modules/0L/FullnodeState.move
+++ b/language/stdlib/modules/0L/FullnodeState.move
@@ -7,7 +7,7 @@ module FullnodeState {
   use 0x1::Errors;
   use 0x1::Signer;
   use 0x1::Testnet::is_testnet;
-  use 0x1::ValidatorConfig;
+  // use 0x1::ValidatorConfig;
   
   resource struct FullnodeCounter {
     proofs_submitted_in_epoch: u64,
@@ -49,21 +49,21 @@ module FullnodeState {
       state.subsidy_in_epoch = 0;
   }
 
-  /// Miner increments proofs by 1
-  /// TO
-  public fun inc_proof(sender: &signer) acquires FullnodeCounter {
-      let addr = Signer::address_of(sender);
-      let state = borrow_global_mut<FullnodeCounter>(addr);
-      state.proofs_submitted_in_epoch = state.proofs_submitted_in_epoch + 1;
-  }
+  // /// Miner increments proofs by 1
+  // /// TO
+  // public fun inc_proof(sender: &signer) acquires FullnodeCounter {
+  //     let addr = Signer::address_of(sender);
+  //     let state = borrow_global_mut<FullnodeCounter>(addr);
+  //     state.proofs_submitted_in_epoch = state.proofs_submitted_in_epoch + 1;
+  // }
 
-  /// Miner increments proofs by 1
-  //Function Code:03
-  public fun inc_proof_by_operator(operator_sig: &signer, miner_addr: address) acquires FullnodeCounter {
-    assert(ValidatorConfig::get_operator(miner_addr) == Signer::address_of(operator_sig), Errors::requires_role(0600103));
-      let state = borrow_global_mut<FullnodeCounter>(miner_addr);
-      state.proofs_submitted_in_epoch = state.proofs_submitted_in_epoch + 1;
-  }
+  // /// Miner increments proofs by 1
+  // //Function Code:03
+  // public fun inc_proof_by_operator(operator_sig: &signer, miner_addr: address) acquires FullnodeCounter {
+  //   assert(ValidatorConfig::get_operator(miner_addr) == Signer::address_of(operator_sig), Errors::requires_role(0600103));
+  //     let state = borrow_global_mut<FullnodeCounter>(miner_addr);
+  //     state.proofs_submitted_in_epoch = state.proofs_submitted_in_epoch + 1;
+  // }
 
   /// VM Increments payments in epoch. Increases by `count`
   // Function code:04

--- a/language/stdlib/modules/0L/FullnodeState.move
+++ b/language/stdlib/modules/0L/FullnodeState.move
@@ -7,7 +7,6 @@ module FullnodeState {
   use 0x1::Errors;
   use 0x1::Signer;
   use 0x1::Testnet::is_testnet;
-  // use 0x1::ValidatorConfig;
   
   resource struct FullnodeCounter {
     proofs_submitted_in_epoch: u64,

--- a/language/stdlib/modules/0L/MinerState.move
+++ b/language/stdlib/modules/0L/MinerState.move
@@ -187,7 +187,7 @@ address 0x1 {
       // TODO: The operator mining needs its own struct to count mining.
       // For now it is implicit there is only 1 operator per validator, and that the fullnode state is the place to count.
       // This will require a breaking change to MinerState
-      FullnodeState::inc_proof_by_operator(operator_sig, miner_addr);
+      // FullnodeState::inc_proof_by_operator(operator_sig, miner_addr);
     }
 
     // Function to verify a proof blob and update a MinerProofHistory

--- a/language/stdlib/modules/0L/Reconfigure.move
+++ b/language/stdlib/modules/0L/Reconfigure.move
@@ -56,6 +56,7 @@ module Reconfigure {
             // check if is in onboarding state (or stuck)
 
             if (FullnodeState::is_onboarding(addr)) {
+              // TODO: onboarding subsidy is not necessary with onboarding transfer.
                 value = Subsidy::distribute_onboarding_subsidy(vm, addr);
             } else {
                 // steady state

--- a/language/stdlib/modules/0L/Reconfigure.move
+++ b/language/stdlib/modules/0L/Reconfigure.move
@@ -41,12 +41,15 @@ module Reconfigure {
 
         let global_proofs_count = 0;
         let k = 0;
+
+        // Distribute mining subsidy to fullnodes
         while (k < Vector::length(&miners)) {
             let addr = *Vector::borrow(&miners, k);
             
             if (!FullnodeState::is_init(addr)) continue; // fail-safe
 
-            let count = FullnodeState::get_address_proof_count(addr);
+            let count = MinerState::get_count_in_epoch(addr);
+            
             global_proofs_count = global_proofs_count + count;
             
             let value: u64;

--- a/language/stdlib/modules/0L/Subsidy.move
+++ b/language/stdlib/modules/0L/Subsidy.move
@@ -27,6 +27,7 @@ address 0x1 {
     use 0x1::FullnodeState;
     use 0x1::ValidatorConfig;
     use 0x1::Debug::print;
+    use 0x1::MinerState;
 
     // estimated gas unit cost for proof verification divided coin scaling factor
     // Cost for verification test/easy difficulty: 1173 / 1000000
@@ -416,7 +417,7 @@ print(&011);
         let oper_addr = ValidatorConfig::get_operator(miner_addr);
         // count OWNER's proofs submitted
 print(&012);
-        let proofs_in_epoch = FullnodeState::get_address_proof_count(miner_addr);
+        let proofs_in_epoch = MinerState::get_count_in_epoch(miner_addr);
 print(&proofs_in_epoch);
         let cost = 0;
         // find cost from baseline


### PR DESCRIPTION
FullnodeState.move has deprecated methods.

- [x] make FullnodeState counters use minerState in Reconfig, and Subsidy
- [x] remove deprecated methods inc_proof