### PR TITLE
miner to read configs from swarm_temp and not from HOME/.0L if starte…

### DIFF
--- a/ol/miner/src/commands.rs
+++ b/ol/miner/src/commands.rs
@@ -14,8 +14,7 @@ use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
 };
 use std::path::PathBuf;
-use dirs;
-use libra_global_constants::NODE_HOME;
+use crate::entrypoint;
 
 /// MinerApp Configuration Filename
 pub const CONFIG_FILE: &str = "0L.toml";
@@ -49,12 +48,11 @@ impl Configurable<AppCfg> for MinerCmd {
         // If you'd like for a missing configuration file to be a hard error
         // instead, always return `Some(CONFIG_FILE)` here.
 
-        let mut config_path = dirs::home_dir()
-        .unwrap();
-        config_path.push(NODE_HOME);
+        let mut config_path = entrypoint::get_node_home();
         config_path.push(CONFIG_FILE);
 
         if config_path.exists() {
+            println!("initializing miner from config file: {:?}", config_path);
             Some(config_path)
         } else {
             None

--- a/ol/miner/src/commands/start_cmd.rs
+++ b/ol/miner/src/commands/start_cmd.rs
@@ -52,11 +52,12 @@ impl Runnable for StartCmd {
             ..
         } = entrypoint::get_args();
 
-        //TODO(mortonbits): In the case of swarm this needs to take from swarm_temp/0/, and not from  ~/.0L, as I think is happening here.
+        // config reading respects swarm setup
+        // so also cfg.get_waypoint will return correct data from swarm config
         let cfg = app_config().clone();
 
         let waypoint = if waypoint.is_none() {
-            match cfg.get_waypoint(swarm_path.clone()) {
+            match cfg.get_waypoint(None) {
                 Some(w) => Some(w),
                 _ => {
                     status_err!("Cannot start without waypoint, exiting");

--- a/ol/miner/src/entrypoint.rs
+++ b/ol/miner/src/entrypoint.rs
@@ -7,6 +7,7 @@ use abscissa_core::{
 use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use reqwest::Url;
 use std::path::PathBuf;
+use libra_global_constants::NODE_HOME;
 
 use crate::commands;
 
@@ -158,4 +159,29 @@ pub type EntryPointTxsCmd = EntryPoint<commands::MinerCmd>;
 /// get arguments passed in the entrypoin of this app, not the subcommands
 pub fn get_args() -> EntryPointTxsCmd {
   Command::from_env_args()
+}
+
+/// returns node_home
+/// usually something like "/root/.0L"
+/// in case of swarm like "....../swarm_temp/0" for alice
+/// in case of swarm like "....../swarm_temp/1" for bob
+pub fn get_node_home() -> PathBuf {
+    let mut config_path = dirs::home_dir().unwrap();
+    config_path.push(NODE_HOME);
+
+    let entry_args = get_args();
+
+    if entry_args.swarm_path.is_some() {
+        config_path = PathBuf::from(entry_args.swarm_path.unwrap());
+        if entry_args.swarm_persona.is_some() {
+            let persona = &entry_args.swarm_persona.unwrap();
+            let all_personas = vec!["alice", "bob", "carol", "dave"];
+            let index = all_personas.iter().position(|&r| r == persona).unwrap();
+            config_path.push(index.to_string());
+        } else {
+            config_path.push("0"); // default
+        }
+    }
+
+    return config_path;
 }


### PR DESCRIPTION
With this update the miner will read configs from the swarm_temp dir and not from $HOME/.0L any longer if started with swarm_path parameter. Also blocks will be stored in swarm_temp directory.

Example usage (no change here compared to before) for alice:
export NODE_ENV="test"
cargo run -p miner -- --swarm-path=.........../swarm_temp --swarm-persona=alice start
 

Prerequisites: "ol-cli init" has to be run before and "blocks" subdirectory has to be pre-filled from fixtures

Example how to establish the prerequisites for alice (after swarm start):
cargo r -p ol-cli -- --swarm-path=.........../swarm_temp --swarm-persona=alice init
mkdir .........../swarm_temp/0/blocks
cp ol/fixtures/blocks/test/alice/* $SWARMDIR/0/blocks