### PR TITLE
added default values for new configurations in 4.3.0

### DIFF
--- a/ol/types/src/config.rs
+++ b/ol/types/src/config.rs
@@ -280,7 +280,7 @@ impl Default for AppCfg {
 
 /// Information about the Chain to mined for
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+/// #[serde(deny_unknown_fields)]
 pub struct Workspace {
     /// home directory of the libra node, may be the same as miner.
     pub node_home: PathBuf,
@@ -289,9 +289,14 @@ pub struct Workspace {
     /// Directory to store blocks in
     pub block_dir: String,
     /// Directory for the database
+    #[serde(default = "default_db_path")]
     pub db_path: PathBuf,
     /// Path to which stdlib binaries for upgrades get built typically /language/stdlib/staged/stdlib.mv
     pub stdlib_bin_path: PathBuf,
+}
+
+fn default_db_path() -> PathBuf {
+    dirs::home_dir().unwrap().join(NODE_HOME).join("db")
 }
 
 impl Default for Workspace {
@@ -300,7 +305,7 @@ impl Default for Workspace {
             node_home: dirs::home_dir().unwrap().join(NODE_HOME),
             source_path: Some(dirs::home_dir().unwrap().join("libra")),
             block_dir: "blocks".to_owned(),
-            db_path: dirs::home_dir().unwrap().join(NODE_HOME).join("db"),
+            db_path: default_db_path(),
             stdlib_bin_path: "/root/libra/language/stdlib/staged/stdlib.mv"
                 .parse::<PathBuf>()
                 .unwrap(),
@@ -386,14 +391,19 @@ pub enum TxType {
 // #[serde(deny_unknown_fields)]
 pub struct TxConfigs {
     /// baseline cost
+    #[serde(default="default_baseline_cost")]
     pub baseline_cost: TxCost,
     /// critical transactions cost
+    #[serde(default="default_critical_txs_cost")]
     pub critical_txs_cost: Option<TxCost>,
     /// management transactions cost
+    #[serde(default="default_management_txs_cost")]
     pub management_txs_cost: Option<TxCost>,
     /// Miner transactions cost
+    #[serde(default="default_miner_txs_cost")]
     pub miner_txs_cost: Option<TxCost>,
     /// Cheap or test transation costs
+    #[serde(default="default_cheap_txs_cost")]
     pub cheap_txs_cost: Option<TxCost>,
 }
 
@@ -439,14 +449,20 @@ impl TxCost {
 impl Default for TxConfigs {
     fn default() -> Self {
         Self {
-            baseline_cost: TxCost::new(10_000),
-            critical_txs_cost: Some(TxCost::new(1_000_000)),
-            management_txs_cost: Some(TxCost::new(100_000)),
-            miner_txs_cost: Some(TxCost::new(10_000)),
-            cheap_txs_cost: Some(TxCost::new(1_000)),
+            baseline_cost: default_baseline_cost(),
+            critical_txs_cost: default_critical_txs_cost(),
+            management_txs_cost: default_management_txs_cost(),
+            miner_txs_cost: default_miner_txs_cost(),
+            cheap_txs_cost: default_cheap_txs_cost(),
         }
     }
 }
+
+fn default_baseline_cost() -> TxCost { TxCost::new(10_000) }
+fn default_critical_txs_cost() -> Option<TxCost> { Some(TxCost::new(1_000_000)) }
+fn default_management_txs_cost() -> Option<TxCost> { Some(TxCost::new(100_000)) }
+fn default_miner_txs_cost() -> Option<TxCost> {Some(TxCost::new(10_000)) }
+fn default_cheap_txs_cost() -> Option<TxCost> { Some(TxCost::new(1_000)) }
 
 /// Get swarm configs from swarm files, swarm must be running
 pub fn get_swarm_configs(mut swarm_path: PathBuf) -> (Url, Waypoint) {


### PR DESCRIPTION
Added default values for all new properties in v4.3.0 compared to v4.2.8 to enable ol-cli to start, even with old config file 0L.toml.

Anyway as an initial step after switching to v4.3.0 the config fix command should be applied:
cargo r -p ol-cli -- init --fix

