### PR TITLE
txs command to read swarm configs

### DIFF
--- a/ol/txs/src/commands.rs
+++ b/ol/txs/src/commands.rs
@@ -23,8 +23,7 @@ mod autopay_cmd;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use ol_cli::commands::CONFIG_FILE;
 use crate::config::AppCfg;
-use dirs;
-use libra_global_constants::NODE_HOME;
+use crate::entrypoint;
 use self::{
     create_account_cmd::CreateAccountCmd,
     create_validator_cmd::CreateValidatorCmd,
@@ -95,10 +94,15 @@ impl Configurable<AppCfg> for TxsCmd {
         // If you'd like for a missing configuration file to be a hard error
         // instead, always return `Some(CONFIG_FILE)` here.
 
-        let mut config_path = dirs::home_dir().unwrap();
-        config_path.push(NODE_HOME);
-        config_path.push(CONFIG_FILE);
+        let mut config_path = entrypoint::get_node_home();
 
-        Some(config_path)
+        config_path.push(CONFIG_FILE);
+        if config_path.exists() {
+            // println!("initializing from config file: {:?}", config_path);
+            Some(config_path)
+        } else {
+            // println!("config file not yet existing: {:?}", config_path);
+            None
+        }
     }
 }

--- a/ol/txs/src/entrypoint.rs
+++ b/ol/txs/src/entrypoint.rs
@@ -5,6 +5,7 @@ use abscissa_core::{
     Options, Runnable    
 };
 use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
+use libra_global_constants::NODE_HOME;
 use reqwest::Url;
 use std::path::PathBuf;
 
@@ -163,4 +164,29 @@ pub type EntryPointTxsCmd = EntryPoint<commands::TxsCmd>;
 pub fn get_args() -> EntryPointTxsCmd {
   let test: EntryPointTxsCmd = Command::from_env_args();
   test
+}
+
+/// returns node_home
+/// usually something like "/root/.0L"
+/// in case of swarm like "....../swarm_temp/0" for alice
+/// in case of swarm like "....../swarm_temp/1" for bob
+pub fn get_node_home() -> PathBuf {
+    let mut config_path = dirs::home_dir().unwrap();
+    config_path.push(NODE_HOME);
+
+    let entry_args = get_args();
+
+    if entry_args.swarm_path.is_some() {
+        config_path = PathBuf::from(entry_args.swarm_path.unwrap());
+        if entry_args.swarm_persona.is_some() {
+            let persona = &entry_args.swarm_persona.unwrap();
+            let all_personas = vec!["alice", "bob", "carol", "dave"];
+            let index = all_personas.iter().position(|&r| r == persona).unwrap();
+            config_path.push(index.to_string());
+        } else {
+            config_path.push("0"); // default
+        }
+    }
+
+    return config_path;
 }


### PR DESCRIPTION
Another part to fix the issues of https://github.com/OLSF/libra/issues/469

With this fix, the txs command reads swarm configs. The examples as in https://github.com/OLSF/libra/wiki/QA-0L-tools-using-Swarm will work then (except the account creation tx, because of an autopay related error).
