### PR TITLE
Node mode parsing

### DIFF
--- a/ol/cli/src/check/pilot.rs
+++ b/ol/cli/src/check/pilot.rs
@@ -11,7 +11,6 @@ use std::{thread, time::Duration};
 /// check the db
 pub fn maybe_restore_db(mut node: &mut Node, verbose: bool) -> &mut Node {
     let cfg = node.conf.to_owned();
-    // let wp = node.client.waypoint().unwrap().to_owned();
     // Abort if the database is not set correctly.
     node.vitals.host_state.onboard_state = OnboardState::EmptyBox;
 
@@ -86,8 +85,7 @@ pub fn run_once(mut node: &mut Node, verbose: bool) -> &mut Node {
             if verbose {
                 println!("Node: account is NOT in validator set");
                   if node.vitals.items.account_created {
-                    println!(".. A
-                    ccount: Owner account does NOT exist on chain. Was the account creation transaction submitted?");
+                    println!(".. Account: Owner account does NOT exist on chain. Was the account creation transaction submitted?");
       
               }
             }
@@ -118,7 +116,7 @@ pub fn run_once(mut node: &mut Node, verbose: bool) -> &mut Node {
             },
             Err(_) => {
                 if verbose {
-                    println!("Node: WARN: could not start node in: {:?}", &start_mode);
+                    println!(".. Node: WARN: could not start node in: {:?}", &start_mode);
                 }
                 NodeState::Stopped
             }

--- a/ol/cli/src/mgmt/management.rs
+++ b/ol/cli/src/mgmt/management.rs
@@ -62,12 +62,12 @@ fn spawn_process(
 
 impl Node {
     /// Start Node, as fullnode
-    pub fn start_node(&mut self, config_type: NodeMode, _verbose: bool) -> Result<(), Error> {
+    pub fn start_node(&mut self, config_type: NodeMode, verbose: bool) -> Result<(), Error> {
         use BINARY_NODE as NODE;
         // if is running do nothing
         // TODO: Get another check of node running
         if node::Node::node_running() {
-            if !_verbose {
+            if verbose {
                 println!("{} is already running. Exiting.", NODE);
             }
             return Ok(());
@@ -83,7 +83,7 @@ impl Node {
 
         let child = if *IS_PROD {
             let args = vec!["--config", &config_file_name];
-            if _verbose {
+            if verbose {
                 println!("Starting '{}' with args: {:?}", NODE, args.join(" "));
             }
             spawn_process(
@@ -97,7 +97,7 @@ impl Node {
             let debug_bin = project_root.join(format!("target/debug/{}", NODE));
             let bin_str = debug_bin.to_str().unwrap();
             let args = vec!["--config", &config_file_name];
-            if _verbose {
+            if verbose {
                 println!("Starting 'libra-node' with args: {:?}", args.join(" "));
             }
             spawn_process(
@@ -111,7 +111,7 @@ impl Node {
         if let Ok(ch) = child {
             let pid = &ch.id();
             self.save_pid(NODE, *pid);
-            if _verbose{
+            if verbose{
                 println!("Started with PID {} in the background", pid);
             }
         }

--- a/ol/cli/src/node/node.rs
+++ b/ol/cli/src/node/node.rs
@@ -7,14 +7,11 @@ use libradb::LibraDB;
 use std::{process::Command, str};
 use sysinfo::SystemExt;
 use sysinfo::{ProcessExt, ProcessStatus};
-
 use libra_json_rpc_client::views::MinerStateResourceView;
 use libra_types::waypoint::Waypoint;
 use libra_types::{account_address::AccountAddress, account_state::AccountState};
 use storage_interface::DbReader;
-
 use super::{account::OwnerAccountView, states::HostState};
-// use std::path::PathBuf;
 
 /// name of key in kv store for sync
 pub const SYNC_KEY: &str = "is_synced";
@@ -25,6 +22,11 @@ pub const NODE_PROCESS: &str = "libra-node";
 /// miner process name:
 pub const MINER_PROCESS: &str = "miner";
 
+/// Node process info
+pub struct ProcInfo {
+    is_running: bool,
+    mode: Option<NodeMode>,
+}
 /// Configuration and state of node, account, and host.
 pub struct Node {
     /// 0L configs
@@ -71,13 +73,13 @@ impl Node {
         // TODO: make SyncState an item, so we don't need to assign.
         // affects web-monitor structs
         if let Ok(s) = self.sync_state() {
-          self.vitals.items.is_synced = s.is_synced;
-          self.vitals.items.sync_delay = s.sync_delay;
-          self.vitals.items.sync_height = s.sync_height
+            self.vitals.items.is_synced = s.is_synced;
+            self.vitals.items.sync_delay = s.sync_delay;
+            self.vitals.items.sync_height = s.sync_height
         } else {
-          self.vitals.items.is_synced = false;
-          self.vitals.items.sync_delay = 404;
-          self.vitals.items.sync_height = 404;
+            self.vitals.items.is_synced = false;
+            self.vitals.items.sync_delay = 404;
+            self.vitals.items.sync_height = 404;
         }
         self.vitals.items.validator_set = self.is_in_validator_set();
         self
@@ -149,7 +151,6 @@ impl Node {
                 false
             }
             None => {
-                //println!("No chain state retrieved");
                 false
             }
         }
@@ -169,7 +170,6 @@ impl Node {
     /// the owner and operator accounts exist on chain
     pub fn accounts_exist_on_chain(&mut self) -> bool {
         let addr = self.conf.profile.account;
-        // dbg!(&addr);
         let account = self.client.get_account(addr, false);
         match account {
             Ok((opt, _)) => match opt {
@@ -205,7 +205,28 @@ impl Node {
 
     /// Check if node is running
     pub fn node_running() -> bool {
-        Node::check_process(NODE_PROCESS) | Node::check_systemd(NODE_PROCESS)
+        Node::node_proc_info().unwrap().is_running
+    }
+
+    /// Check if node is running
+    fn node_proc_info() -> Result<ProcInfo, Error> {
+        let info = if Node::check_process(NODE_PROCESS) {
+            ProcInfo {
+                is_running: true,
+                mode: Node::node_mode_foreground().ok(),
+            }
+        } else if Node::check_systemd(NODE_PROCESS) {
+            ProcInfo {
+                is_running: true,
+                mode: Node::node_mode_systemd().ok(),
+            }
+        } else {
+           ProcInfo {
+                is_running: false,
+                mode: None,
+            }
+        };
+        Ok(info)
     }
 
     /// Check if miner is running
@@ -219,7 +240,6 @@ impl Node {
         system.refresh_all();
 
         let all_p = system.get_process_by_name("ol");
-        // dbg!(&all_p);
         let process = all_p
             .into_iter()
             .filter(|i| match i.status() {
@@ -229,7 +249,8 @@ impl Node {
             })
             .find(|i| !i.cmd().is_empty());
 
-        process.unwrap()
+        process
+            .unwrap()
             .cmd()
             .into_iter()
             .find(|s| s.contains(&"pilot".to_owned()))
@@ -246,74 +267,87 @@ impl Node {
                 return true;
             }
         }
-        // aldo try by name (yield different results), most reliable.
+        // also try by name (yield different results), most reliable.
         let p = system.get_process_by_name(process_str);
         !p.is_empty()
     }
     /// check what mode the node is running in
     pub fn what_node_mode() -> Result<NodeMode, Error> {
-        // check systemd first
-        if Node::node_running() {
-            let output = Command::new("service")
-                .args(&["libra-node", "status"])
-                .output();
-            match output {
-                Ok(out) => {
-                    let text = str::from_utf8(&out.stdout.as_slice()).unwrap();
-                    if text.contains("validator") {
-                        return Ok(NodeMode::Validator);
-                    }
-                    if text.contains("fullnode") {
-                        return Ok(NodeMode::Fullnode);
-                    }
-                }
-                Err(e) => return Err(Error::from(e)),
+        match Node::node_proc_info() {
+            Ok(proc) => {
+              match proc.mode {
+                Some(m) => Ok(m),
+                None => Err(Error::msg("no node mode found"))
             }
+            },
+            Err(e) => Err(e)
+        }
+    }
 
-            // check as parent process
-            let mut system = sysinfo::System::new_all();
-            system.refresh_all();
-            let all_p = system.get_process_by_name(NODE_PROCESS);
-            // dbg!(&all_p);
-            let process = all_p
-                .into_iter()
-                .filter(|i| match i.status() {
-                    ProcessStatus::Run => true,
-                    ProcessStatus::Sleep => true,
-                    _ => false,
-                })
-                .find(|i| !i.cmd().is_empty());
-
-            if let Some(p) = process {
-                let is_val = p
-                    .cmd()
-                    .into_iter()
-                    .find(|s| s.contains(&"validator".to_owned()))
-                    .is_some();
-                if is_val {
+    /// check what mode the node is running in
+    pub fn node_mode_systemd() -> Result<NodeMode, Error> {
+        let output = Command::new("service")
+            .args(&["libra-node", "status"])
+            .output();
+        match output {
+            Ok(out) => {
+                let text = str::from_utf8(&out.stdout.as_slice()).unwrap();
+                if text.contains("validator") {
                     return Ok(NodeMode::Validator);
-                }
-
-                let is_fn = p
-                    .cmd()
-                    .into_iter()
-                    .find(|s| s.contains(&"fullnode".to_owned()))
-                    .is_some();
-                if is_fn {
+                } else if text.contains("fullnode") {
                     return Ok(NodeMode::Fullnode);
                 }
+            }
+            Err(e) => return Err(Error::from(e)),
+        }
+        Err(Error::msg("no systemd mode found"))
+    }
 
-                let is_fn = p
-                    .cmd()
-                    .into_iter()
-                    .find(|s| s.contains(&"swarm".to_owned()))
-                    .is_some();
-                if is_fn {
-                    return Ok(NodeMode::Validator);
-                }
+    /// check what mode the node is running in
+    pub fn node_mode_foreground() -> Result<NodeMode, Error> {
+        // check as parent process
+        let mut system = sysinfo::System::new_all();
+        system.refresh_all();
+        let all_p = system.get_process_by_name(NODE_PROCESS);
+        // dbg!(&all_p);
+        let process = all_p
+            .into_iter()
+            .filter(|i| match i.status() {
+                ProcessStatus::Run => true,
+                ProcessStatus::Sleep => true,
+                _ => false,
+            })
+            .find(|i| !i.cmd().is_empty());
+
+        if let Some(p) = process {
+            let is_val = p
+                .cmd()
+                .into_iter()
+                .find(|s| s.contains(&"validator".to_owned()))
+                .is_some();
+            if is_val {
+                return Ok(NodeMode::Validator);
+            }
+
+            let is_fn = p
+                .cmd()
+                .into_iter()
+                .find(|s| s.contains(&"fullnode".to_owned()))
+                .is_some();
+            if is_fn {
+                return Ok(NodeMode::Fullnode);
+            }
+
+            let is_fn = p
+                .cmd()
+                .into_iter()
+                .find(|s| s.contains(&"swarm".to_owned()))
+                .is_some();
+            if is_fn {
+                return Ok(NodeMode::Validator);
             }
         }
-        Err(Error::msg("node is not running"))
+        Err(Error::msg("no mode found in process"))
     }
 
     /// is web monitor serving on 3030

--- a/ol/util/install.sh
+++ b/ol/util/install.sh
@@ -1,3 +1,4 @@
+apt install -y unzip zip jq
 DOWNLOAD_URLS=$(curl -sL https://api.github.com/repos/OLSF/libra/releases/latest | jq -r '.assets[].browser_download_url')
 
 


### PR DESCRIPTION
Patches the `ol` cli so that it correctly identifies the node mode, even when systemd has been used concurrently as foreground libra-node processes.