### PR TITLE
Fixed: Tx panics should not stop miner (#520)

### DIFF
--- a/client/json-rpc/src/blocking.rs
+++ b/client/json-rpc/src/blocking.rs
@@ -64,6 +64,7 @@ impl JsonRpcClient {
     }
 
     fn send(&self, request: &serde_json::Value) -> Result<reqwest::blocking::Response> {
+
         self.client
             .post(self.url.clone())
             .json(request)

--- a/client/json-rpc/src/lib.rs
+++ b/client/json-rpc/src/lib.rs
@@ -5,7 +5,7 @@ mod blocking;
 mod client;
 mod response;
 
-pub use blocking::JsonRpcClient;
+pub use blocking::{JsonRpcClient};
 pub use client::{
     get_response_from_batch, process_batch_response, JsonRpcAsyncClient, JsonRpcAsyncClientError,
     JsonRpcBatch,

--- a/ol/miner/src/block.rs
+++ b/ol/miner/src/block.rs
@@ -120,7 +120,7 @@ pub fn mine_and_submit(
 
             // submits backlog to client
             match backlog::process_backlog(&config, &tx_params, is_operator) {
-                Ok(()) => status_ok!("Success:", "backlog committed to chain"),
+                Ok(()) => status_ok!("Success:", "Proof committed to chain"),
                 Err(e) => {
                     status_warn!("Failed fetching remote state: {}", e);
                 }
@@ -152,7 +152,6 @@ pub fn parse_block_height(blocks_dir: &PathBuf) -> (Option<u64>, Option<PathBuf>
     let mut max_block_path = None;
 
     // iterate through all json files in the directory.
-    println!("{}/block_*.json", blocks_dir.display());
     for entry in glob(&format!("{}/block_*.json", blocks_dir.display()))
         .expect("Failed to read glob pattern")
     {

--- a/ol/miner/src/commands/start_cmd.rs
+++ b/ol/miner/src/commands/start_cmd.rs
@@ -76,7 +76,12 @@ impl Runnable for StartCmd {
         // Check for, and submit backlog proofs.
         if !self.skip_backlog {
           // TODO: remove is_operator from signature, since tx_params has it.
-            backlog::process_backlog(&cfg, &tx_params, is_operator);
+            match backlog::process_backlog(&cfg, &tx_params, is_operator) {
+                Ok(()) => status_ok!("Success:", "backlog committed to chain"),
+                Err(e) => {
+                    println!("Failed fetching remote state: {}", e);
+                }
+            }
         }
 
         println!("url: {}", tx_params.url.clone());

--- a/ol/miner/src/commands/start_cmd.rs
+++ b/ol/miner/src/commands/start_cmd.rs
@@ -79,6 +79,8 @@ impl Runnable for StartCmd {
             backlog::process_backlog(&cfg, &tx_params, is_operator);
         }
 
+        println!("url: {}", tx_params.url.clone());
+        
         if !self.backlog_only {
             // Steady state.
             let result = mine_and_submit(&cfg, tx_params, is_operator);

--- a/ol/miner/src/commands/start_cmd.rs
+++ b/ol/miner/src/commands/start_cmd.rs
@@ -77,7 +77,7 @@ impl Runnable for StartCmd {
         if !self.skip_backlog {
           // TODO: remove is_operator from signature, since tx_params has it.
             match backlog::process_backlog(&cfg, &tx_params, is_operator) {
-                Ok(()) => status_ok!("Success:", "backlog committed to chain"),
+                Ok(()) => status_ok!("Backlog:", "backlog committed to chain"),
                 Err(e) => {
                     println!("Failed fetching remote state: {}", e);
                 }

--- a/ol/miner/src/commit_proof.rs
+++ b/ol/miner/src/commit_proof.rs
@@ -5,7 +5,6 @@ use cli::{libra_client::LibraClient, AccountData, AccountStatus};
 use txs::{sign_tx::sign_tx, submit_tx::{TxParams, submit_tx}};
 use libra_types::transaction::{Script};
 use libra_json_rpc_types::views::{TransactionView};
-use libra_types::chain_id::ChainId;
 
 /// Submit a miner transaction to the network.
 pub fn commit_proof_tx(
@@ -18,7 +17,7 @@ pub fn commit_proof_tx(
     // Create a client object
     let mut client = LibraClient::new(tx_params.url.clone(), tx_params.waypoint).unwrap();
 
-    let chain_id = ChainId::new(client.get_metadata()?.chain_id);
+    let chain_id = tx_params.chain_id;
 
     // For sequence number
     let (account_state,_) = client.get_account(tx_params.signer_address.clone(), true)?;

--- a/ol/miner/src/commit_proof.rs
+++ b/ol/miner/src/commit_proof.rs
@@ -18,10 +18,10 @@ pub fn commit_proof_tx(
     // Create a client object
     let mut client = LibraClient::new(tx_params.url.clone(), tx_params.waypoint).unwrap();
 
-    let chain_id = ChainId::new(client.get_metadata().unwrap().chain_id);
+    let chain_id = ChainId::new(client.get_metadata()?.chain_id);
 
     // For sequence number
-    let (account_state,_) = client.get_account(tx_params.signer_address.clone(), true).unwrap();
+    let (account_state,_) = client.get_account(tx_params.signer_address.clone(), true)?;
     let sequence_number = match account_state {
         Some(av) => av.sequence_number,
         None => 0,

--- a/ol/miner/src/lib.rs
+++ b/ol/miner/src/lib.rs
@@ -8,11 +8,11 @@
 
 #![forbid(unsafe_code)]
 #![warn(
-    missing_docs,
-    rust_2018_idioms,
-    trivial_casts,
-    unused_lifetimes,
-    unused_qualifications
+missing_docs,
+rust_2018_idioms,
+trivial_casts,
+unused_lifetimes,
+unused_qualifications
 )]
 
 pub mod prelude;

--- a/ol/miner/tests/integration-submit-tx.rs
+++ b/ol/miner/tests/integration-submit-tx.rs
@@ -8,6 +8,7 @@ use txs::submit_tx::{TxParams, get_tx_params_from_swarm};
 use anyhow::{bail, Error};
 
 #[test]
+#[ignore]
 /// In case the miner fails to connect with client, miner should continue mining 
 /// and submit the backlog on each block. This test simulates this issue by blocking 
 /// the port in between and testing the connectivity. 

--- a/ol/miner/tests/integration-submit-tx.rs
+++ b/ol/miner/tests/integration-submit-tx.rs
@@ -92,7 +92,8 @@ pub fn integration_submit_tx() {
 
             // TODO: make these paths references
             let tx_params = get_tx_params_from_swarm(swarm_configs_path.clone(), "alice".to_owned(), false).unwrap();// TO write logic
-            let config =  AppCfg::init_app_configs_swarm(swarm_configs_path.clone(), swarm_configs_path.join("0"));
+            let config =  AppCfg::init_app_configs_swarm(swarm_configs_path.clone(), 
+                                    swarm_configs_path.join("0"), Some(root_source_path.clone().to_path_buf()));
 
             let mut blocks_dir = config.workspace.node_home.clone();
             blocks_dir.push(&config.workspace.block_dir);

--- a/ol/miner/tests/integration-submit-tx.rs
+++ b/ol/miner/tests/integration-submit-tx.rs
@@ -1,0 +1,219 @@
+
+#![forbid(unsafe_code)]
+
+use std::{fs, path::{Path}, process::{Command, Stdio}, thread, time::{self, Duration}};
+use libra_config::config::NodeConfig;
+use ol::config::AppCfg;
+use txs::submit_tx::{TxParams, get_tx_params_from_swarm};
+use anyhow::{bail, Error};
+
+#[test]
+#[ignore]
+/// In case the miner fails to connect with client, miner should continue mining 
+/// and submit the backlog on each block. This test simulates this issue by blocking 
+/// the port in between and testing the connectivity. 
+pub fn integration_submit_tx() {
+    
+    // the miner needs to start producing block_1.json. If block_1.json is not successful, then block_2 cannot be either, because it depends on certain on-chain state from block_1 correct submission.
+    let miner_source_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root_source_path = miner_source_path.parent().unwrap().parent().unwrap();
+    let home = dirs::home_dir().unwrap();
+    let swarm_configs_path = home.join(".0L/swarm_temp/");
+
+    match fs::remove_dir_all(&swarm_configs_path) {
+        Ok(_) => { println!("wiping swarm temp directory! {:?}", &swarm_configs_path)},
+        Err(_) => {},
+    }
+
+    let node_exec = &root_source_path.join("target/debug/libra-node");
+    // TODO: Assert that block_0.json is in blocks folder.
+    std::env::set_var("RUST_LOG", "debug");
+    let mut swarm_cmd = Command::new("cargo");
+    swarm_cmd.current_dir(&root_source_path.as_os_str());
+    swarm_cmd.arg("run")
+            .arg("-p").arg("libra-swarm")
+            .arg("--")
+            .arg("-n").arg("1")
+            .arg("--libra-node").arg(node_exec.to_str().unwrap())
+            .arg("-c").arg(swarm_configs_path.to_str().unwrap());
+    let cmd = swarm_cmd.stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn();
+    match cmd {
+        // Swarm has started
+        Ok(mut swarm_child) => {
+            // need to wait for swarm to start-up before we have the configs needed to connect to it. Check stdout.
+            block_until_swarm_ready();
+            println!("READY!");
+            // wait a bit more, because the previous command only checks for config fils creation.
+            let test_timeout = Duration::from_secs(30);
+            thread::sleep(test_timeout);
+
+                        // start the miner swarm test helper.
+            let mut init_cmd = Command::new("cargo");
+            init_cmd.arg("run")
+                    .arg("-p")
+                    .arg("ol")
+                    .arg("--")
+                    .arg("--swarm-path")
+                    .arg(swarm_configs_path.to_str().unwrap())
+                    .arg("--swarm-persona")
+                    .arg("alice")
+                    .arg("init")
+                    .arg("--source-path")
+                    .arg(root_source_path.to_str().unwrap());
+            let mut init_child = init_cmd.stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .spawn()
+                    .unwrap();
+            init_child.wait().unwrap();
+
+            // start the miner swarm test helper.
+            let mut miner_cmd = Command::new("cargo");
+            miner_cmd.arg("run")
+                    .arg("-p")
+                    .arg("miner")
+                    .arg("--")
+                    .arg("--swarm-path")
+                    .arg(swarm_configs_path.to_str().unwrap())
+                    .arg("--swarm-persona")
+                    .arg("alice")
+                    .arg("start");
+            let mut miner_child = miner_cmd.stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .spawn()
+                    .unwrap();
+
+            // TODO: need to parse output of the stdio
+
+            // set a timeout. Let the node run for sometime. 
+            let test_timeout = Duration::from_secs(30);
+            thread::sleep(test_timeout);
+
+            // TODO: make these paths references
+            let tx_params = get_tx_params_from_swarm(swarm_configs_path.clone(), "alice".to_owned(), false).unwrap();// TO write logic
+            let config =  AppCfg::init_app_configs_swarm(swarm_configs_path.clone(), swarm_configs_path.join("0"));
+
+            let mut blocks_dir = config.workspace.node_home.clone();
+            blocks_dir.push(&config.workspace.block_dir);
+
+
+            let (current_block_number, _current_block_path) = miner::block::parse_block_height(&blocks_dir);
+            let block_number_before_block = current_block_number.unwrap();
+            
+
+            println!("Check node sync before disabling port");
+            match check_node_sync(&tx_params, &config) {
+                Ok(()) => {},
+                Err(err) => {
+                    swarm_child.kill().unwrap();
+                    miner_child.kill().unwrap();
+                    std::panic!("Check node sync failed: {}", err)
+                }
+            };
+                
+            let port = get_node_port(); // node port
+
+            // Block the port
+            println!("Blocking the port: {}", port);
+            let mut block_port_cmd = Command::new("sudo");
+            block_port_cmd.arg("iptables").arg("-A").arg("OUTPUT").arg("-p")
+                .arg("tcp").arg("--match").arg("multiport").arg("--dports")
+                .arg(port.to_string()).arg("-j").arg("DROP");
+            block_port_cmd.stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .unwrap();
+            
+            
+
+            // let miner mine without submitting
+            let test_timeout = Duration::from_secs(240); // To let the timeout happen and continue mining. 
+            thread::sleep(test_timeout);
+            
+            let (current_block_number, _current_block_path) = miner::block::parse_block_height(&blocks_dir);
+            let block_number_after_unblock = current_block_number.unwrap();
+            
+            // Miner should have continued mining. +1 to consider atleast 2 blocks mined. 
+            if block_number_after_unblock <= (block_number_before_block + 1) {
+                std::panic!("Miner did not mine during port block: Blocks Before block: {}, blocks after unblock: {}", block_number_before_block, block_number_after_unblock);
+            }
+
+            // activate the port
+            println!("Reactivate the port: {}", port);
+            let mut activate_port_cmd = Command::new("sudo");
+            activate_port_cmd.arg("iptables").arg("-D").arg("OUTPUT").arg("-p")
+                .arg("tcp").arg("--match").arg("multiport").arg("--dports")
+                .arg(port.to_string()).arg("-j").arg("DROP");
+            activate_port_cmd.stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .unwrap();
+            
+            // let miner submit the backlog
+            let test_timeout = Duration::from_secs(120); // enough time to submit back log
+            thread::sleep(test_timeout);
+            println!("Check node sync after disabling port");
+            match check_node_sync(&tx_params, &config) {
+                Ok(()) => {},
+                Err(err) => {
+                    swarm_child.kill().unwrap();
+                    miner_child.kill().unwrap();
+                    std::panic!("Check node sync failed after block & re-active port: {}", err)
+                }
+            };
+
+            swarm_child.kill().unwrap();
+            miner_child.kill().unwrap();
+            
+        }
+        Err(err) => println!("Swarm child process did not start: {}", err)
+    }
+}
+
+fn block_until_swarm_ready() -> bool {
+    let home = dirs::home_dir().unwrap();
+    let swarm_configs_path = home.join("swarm_temp/");
+    let mut timeout = 100;
+    let one_second = time::Duration::from_secs(1);
+
+    loop {
+        if timeout == 0 { 
+            return false
+        }
+        if swarm_configs_path.exists() {
+            return true
+        }
+
+        thread::sleep(one_second);
+        timeout -= 1;
+    }
+}
+
+fn get_node_port() -> u16 {
+    let home = dirs::home_dir().unwrap();
+    let swarm_configs_path = home.join(".0L/swarm_temp/");
+    
+    let yaml_path = swarm_configs_path.join("0/node.yaml");
+    let node_conf = NodeConfig::load(&yaml_path).unwrap();
+
+    node_conf.json_rpc.address.port()
+}
+
+fn check_node_sync(tx_params: &TxParams, config: &AppCfg) -> Result<(), Error> {
+    let remote_state = miner::backlog::get_remote_state(&tx_params).unwrap();
+    let remote_height = remote_state.verified_tower_height;
+    println!("Remote tower height: {}", remote_height);
+
+    let mut blocks_dir = config.workspace.node_home.clone();
+    blocks_dir.push(&config.workspace.block_dir);
+    let (current_block_number, _current_block_path) = miner::block::parse_block_height(&blocks_dir);
+    let current_block_number = current_block_number.unwrap();
+    println!("Local tower height: {}", current_block_number);
+
+    // The client can be in sync with local or -1 wrt local. 
+    if (current_block_number != remote_height) && (current_block_number - 1)!= remote_height {
+        bail!("Block heights don't match: Miner: {}, Remote: {}", current_block_number, remote_height)
+    }
+    Ok(())
+}

--- a/ol/miner/tests/integration-submit-tx.rs
+++ b/ol/miner/tests/integration-submit-tx.rs
@@ -8,7 +8,6 @@ use txs::submit_tx::{TxParams, get_tx_params_from_swarm};
 use anyhow::{bail, Error};
 
 #[test]
-#[ignore]
 /// In case the miner fails to connect with client, miner should continue mining 
 /// and submit the backlog on each block. This test simulates this issue by blocking 
 /// the port in between and testing the connectivity. 
@@ -30,7 +29,8 @@ pub fn integration_submit_tx() {
     std::env::set_var("RUST_LOG", "debug");
     let mut swarm_cmd = Command::new("cargo");
     swarm_cmd.current_dir(&root_source_path.as_os_str());
-    swarm_cmd.arg("run")
+    swarm_cmd.env("NODE_ENV", "test")
+            .arg("run")
             .arg("-p").arg("libra-swarm")
             .arg("--")
             .arg("-n").arg("1")
@@ -70,7 +70,8 @@ pub fn integration_submit_tx() {
 
             // start the miner swarm test helper.
             let mut miner_cmd = Command::new("cargo");
-            miner_cmd.arg("run")
+            miner_cmd.env("NODE_ENV", "test")
+                    .arg("run")
                     .arg("-p")
                     .arg("miner")
                     .arg("--")

--- a/ol/txs/src/submit_tx.rs
+++ b/ol/txs/src/submit_tx.rs
@@ -35,6 +35,7 @@ use std::{
     path::PathBuf,
     thread, time,
 };
+
 /// All the parameters needed for a client transaction.
 #[derive(Debug)]
 pub struct TxParams {
@@ -161,6 +162,8 @@ fn stage(
     (signer_account_data, txn)
 }
 /// Submit a transaction to the network.
+
+
 pub fn submit_tx(
     mut client: LibraClient,
     txn: SignedTransaction,
@@ -386,6 +389,8 @@ pub fn wait_for_tx(
         signer_address, sequence_number
     );
 
+    let mut iter = 0;
+    const MAX_ITERATIONS: u8 = 10; // 5000 * 2/1000
     loop {
         thread::sleep(time::Duration::from_millis(1000));
         // prevent all the logging the client does while
@@ -402,6 +407,11 @@ pub fn wait_for_tx(
             _ => {
                 print!(".");
             }
+        }
+        iter += 1;
+
+        if iter==MAX_ITERATIONS {
+            return None;
         }
     }
 }

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -64,7 +64,7 @@ impl LibraClient {
             latest_epoch_change_li: None,
         })
     }
-
+    
     /// Submits a transaction and bumps the sequence number for the sender, pass in `None` for
     /// sender_account if sender's address is not managed by the client.
     pub fn submit_transaction(


### PR DESCRIPTION
## Motivation
The is pull request solves the issue raised here: https://github.com/OLSF/libra/issues/520

## Test Plan
A test has been written at https://github.com/VenkatTeja/libra/blob/256ee6ca7aaa0590607790f7f4bfe5f54051d036/ol/miner/tests/integration-submit-tx.rs

The test tries to block the client port using iptables and after sometime checks if miner was able to mine more blocks than before blocking port. Then the port is unblocked and the tests waits for miner to submit the backlog. The test checks again after sometime to check if client is in sync with miner. 
