### PR TITLE
Restore to use tar instead of unzip

### DIFF
--- a/ol/cli/src/commands/restore_cmd.rs
+++ b/ol/cli/src/commands/restore_cmd.rs
@@ -21,6 +21,9 @@ pub struct RestoreCmd {
 impl Runnable for RestoreCmd {
     /// Start the application.
     fn run(&self) {
-        mgmt::restore::fast_forward_db(self.verbose, self.epoch).unwrap();
+        match mgmt::restore::fast_forward_db(self.verbose, self.epoch) {
+            Ok(_) => {},
+            Err(e) => println!("ERROR: could not complete db restore, message: {:?}", e),
+        };
     }
 }

--- a/ol/cli/src/mgmt/restore.rs
+++ b/ol/cli/src/mgmt/restore.rs
@@ -121,14 +121,27 @@ impl Backup {
         
         let stdio_cfg = if verbose { Stdio::inherit() } else { Stdio::null() };
         let restore_dir = &self.home_path.join("restore/");
-        let mut child = Command::new("unzip")
-        .arg("-o")
+
+        // replace zip for tar
+        // tar -xf archive.tar.gz -C
+        let mut child = Command::new("tar")
+        .arg("-xf")
         .arg(&self.zip_path)
-        .arg("-d")
+        .arg("-C")
         .arg(restore_dir)
         .stdout(stdio_cfg)
         .spawn()
         .expect(&format!("failed to unzip {:?} into {:?}", &self.zip_path, restore_dir));
+
+
+        // let mut child = Command::new("unzip")
+        // .arg("-o")
+        // .arg(&self.zip_path)
+        // .arg("-d")
+        // .arg(restore_dir)
+        // .stdout(stdio_cfg)
+        // .spawn()
+        // .expect(&format!("failed to unzip {:?} into {:?}", &self.zip_path, restore_dir));
 
         let ecode = child.wait().expect("failed to wait on child");
 
@@ -250,7 +263,7 @@ fn get_highest_epoch_zip() -> Result<(u64, String), Error> {
     // TODO: Change to new directory structure
     Ok(
         (highest_epoch, 
-            format!("https://raw.githubusercontent.com/{owner}/{repo}/main/{highest_epoch}.zip",
+            format!("https://raw.githubusercontent.com/{owner}/{repo}/main/{highest_epoch}.tar.gz",
         owner = GITHUB_ORG.clone(),
         repo = GITHUB_REPO.clone(),
         highest_epoch = highest_epoch.to_string(),
@@ -261,7 +274,7 @@ fn get_highest_epoch_zip() -> Result<(u64, String), Error> {
 fn get_zip_url(epoch: u64) -> Result<String, Error> {
     Ok( 
       format!(
-        "https://raw.githubusercontent.com/{owner}/{repo}/main/{epoch}.zip",
+        "https://raw.githubusercontent.com/{owner}/{repo}/main/{epoch}.tar.gz",
         owner = GITHUB_ORG.clone(),
         repo = GITHUB_REPO.clone(),
         epoch = epoch.to_string(),

--- a/ol/onboard/src/commands/fix_cmd.rs
+++ b/ol/onboard/src/commands/fix_cmd.rs
@@ -51,6 +51,8 @@ pub fn migrate_account_json(cfg: &AppCfg) {
   let (_, _, wallet) = wallet::get_account_from_prompt();
   let home_path = cfg.workspace.node_home.clone();
   println!("Reading autopay configs");
+  println!("\nTHIS IS NOT SUBMITTING TXs, only formatting files.\n");
+
   let (autopay_batch, autopay_signed) = get_autopay_batch(
         &None,
         &None,
@@ -69,7 +71,7 @@ pub fn migrate_account_json(cfg: &AppCfg) {
       fs::copy(&account_json_path, &backup_path).expect("could not backup account.json");
     }
 
-    migrate_autopay_json_4_3_0(cfg, autopay_batch.clone().unwrap());
+    migrate_autopay_json_format(cfg, autopay_batch.clone().unwrap());
 
     println!("writing account.json to {:?}", cfg.workspace.node_home.clone());
 
@@ -85,9 +87,8 @@ pub fn migrate_account_json(cfg: &AppCfg) {
 
 
 /// migrate autopay.json for archive purposes
-pub fn migrate_autopay_json_4_3_0(cfg: &AppCfg, instructions: Vec<PayInstruction>) {
+pub fn migrate_autopay_json_format(cfg: &AppCfg, instructions: Vec<PayInstruction>) {
   let file_path = cfg.workspace.node_home.clone().join("back.autopay_batch.json");
-
   println!("\nmigrating autopay_batch.json to {:?}\n", &file_path);
 
   let vec_instr: Vec<PayInstruction> = instructions.into_iter()

--- a/ol/txs/src/commands/autopay_batch_cmd.rs
+++ b/ol/txs/src/commands/autopay_batch_cmd.rs
@@ -43,6 +43,8 @@ impl Runnable for AutopayBatchCmd {
         let epoch = node.vitals.chain_view.unwrap().epoch;
         println!("The current epoch is: {}\n", epoch);
         
+        println!("Next you will confirm the instructions before sending the batch transaction\n ALL INSTRUCTIONS MUST BE CONFIRMED before the tx submission happens. Batches are atomic. If you reject one transaction, no batch will be submitted, and you must revise the batch.json file");
+
         let instructions = PayInstruction::parse_autopay_instructions(&self.autopay_batch_file, Some(epoch), start_id).unwrap();
         let scripts = process_instructions(instructions);
         batch_wrapper(scripts, &tx_params, entry_args.no_send, entry_args.save_path)


### PR DESCRIPTION
Restore was depending on Unzip. And for users not using sudo and attempting "easy mode", installing the dependency could be a pain.

Also update some of the prints in cli

- [x] restore: was panicking instead of returning the source of error.
- [x] onboard fix: remind people no transactions are being sent at the time.
- [x] batch tx instructions: remind people all batch txs need to be approved otherwise the batch is not sent.