### PR TITLE
Query payment events from cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,7 @@ dependencies = [
  "gumdrop",
  "handlebars",
  "hex 0.4.2",
+ "libra-canonical-serialization",
  "libra-config",
  "libra-genesis-tool",
  "libra-global-constants",

--- a/ol/cli/Cargo.toml
+++ b/ol/cli/Cargo.toml
@@ -60,6 +60,7 @@ gag = "0.1.10"
 port_scanner = "0.1.5"
 backup-cli = { path = "../../storage/backup/backup-cli", version = "0.1.0" }
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 
 # Parity with Storage create
 [dependencies.rocksdb]

--- a/ol/cli/src/commands/query_cmd.rs
+++ b/ol/cli/src/commands/query_cmd.rs
@@ -113,11 +113,10 @@ impl Runnable for QueryCmd {
             display = "EPOCH";
         } else if self.events_received {
             
-            info = node.query(QueryType::Events{account, sent_or_received: false});
+            info = node.query(QueryType::Events{account, sent_or_received: false, seq_start: self.txs_height});
             display = "EVENTS";
         } else if self.events_sent {
-
-            info = node.query(QueryType::Events{account, sent_or_received: true});
+            info = node.query(QueryType::Events{account, sent_or_received: true, seq_start: self.txs_height});
             display = "EVENTS";
         }
         else if self.txs {

--- a/ol/cli/src/commands/query_cmd.rs
+++ b/ol/cli/src/commands/query_cmd.rs
@@ -38,6 +38,12 @@ pub struct QueryCmd {
     #[options(help = "get last transactions, defaults to last 100")]
     txs: bool,
 
+    #[options(help = "get last payment events SENT, defaults to last 100")]
+    events_sent: bool,
+    
+    #[options(help = "get last payment events RECEIVED, defaults to last 100")]
+    events_received: bool,
+
     #[options(help = "height to start txs query from, defaults to -100_000 blocks")]
     txs_height: Option<u64>,
 
@@ -105,6 +111,14 @@ impl Runnable for QueryCmd {
         else if self.epoch {
             info = node.query(QueryType::Epoch);
             display = "EPOCH";
+        } else if self.events_received {
+            
+            info = node.query(QueryType::Events{account, sent_or_received: false});
+            display = "EVENTS";
+        } else if self.events_sent {
+
+            info = node.query(QueryType::Events{account, sent_or_received: true});
+            display = "EVENTS";
         }
         else if self.txs {
             info = node.query(

--- a/ol/cli/src/events.depr
+++ b/ol/cli/src/events.depr
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use cli::libra_client::LibraClient;
+use libra_json_rpc_client::views::EventView;
+use libra_types::{
+    account_address::AccountAddress,
+    account_state::AccountState,
+    event::{EventHandle, EventKey},
+};
+use std::convert::TryFrom;
+
+const BATCH_SIZE: u64 = 500;
+
+pub struct EventsFetcher(LibraClient);
+
+impl EventsFetcher {
+    pub fn new(client: LibraClient) -> Result<Self> {
+        Ok(Self(client))
+    }
+
+    fn get_account_state(&mut self, account: AccountAddress) -> Result<Option<AccountState>> {
+        let blob = self
+        .0
+        .get_account_state_blob(account)
+        .unwrap()
+        .0
+        .unwrap();
+
+        Ok(Some(AccountState::try_from(&blob)?))
+    }
+
+    pub fn get_payment_event_handles(
+        &mut self,
+        account: AccountAddress,
+    ) -> Result<Option<(EventHandle, EventHandle)>> {
+        match self.get_account_state(account)? {
+            Some(account_state) => {
+              let handles = account_state
+              .get_account_resource()?
+              .map(|resource| {
+                (
+                    resource.sent_events().clone(),
+                    resource.received_events().clone(),
+                )
+            });
+            Ok(handles)
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_events(
+        &mut self,
+        event_key: &EventKey,
+        start: u64,
+        limit: u64,
+    ) -> Result<Vec<EventView>> {
+        let key = hex::encode(event_key.as_bytes());
+        self
+        .0
+        .get_events(key, start, limit)
+    }
+
+    pub fn get_handle_events(&mut self, event_handle: &EventHandle) -> Result<Vec<EventView>> {
+        if event_handle.count() == 0 {
+            return Ok(vec![]);
+        }
+        let mut futures = vec![];
+        let mut i: u64 = 0;
+        while i.wrapping_add(BATCH_SIZE) < event_handle.count() {
+            futures.push(self.get_events(event_handle.key(), i, BATCH_SIZE));
+            i = i.wrapping_add(BATCH_SIZE);
+        }
+        self.get_events(
+          event_handle.key(), 
+          i, 
+          event_handle.count().wrapping_sub(i)
+        )
+    }
+}

--- a/ol/cli/src/node/account.rs
+++ b/ol/cli/src/node/account.rs
@@ -2,8 +2,8 @@
 
 use crate::node::node::Node;
 use anyhow::{Error, Result};
-use libra_json_rpc_client::{views::AccountView, AccountAddress};
-use libra_types::{account_state::AccountState, transaction::Version};
+use libra_json_rpc_client::{views::{AccountView, EventView}, AccountAddress};
+use libra_types::{account_state::AccountState, event::{EventHandle, EventKey}, transaction::Version};
 use resource_viewer::{AnnotatedAccountStateBlob, MoveValueAnnotator, NullStateView};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -104,6 +104,48 @@ impl Node {
         } else {
             Err(Error::msg("connection to client"))
         }
+    }
+
+    pub fn get_payment_event_handles(
+        &mut self,
+        account: AccountAddress,
+    ) -> Result<Option<(EventHandle, EventHandle)>, Error> {
+        match self.get_account_state(account) {
+            Ok(account_state) => {
+              let handles = account_state
+              .get_account_resource()?
+              .map(|resource| {
+                (
+                    resource.sent_events().clone(),
+                    resource.received_events().clone(),
+                )
+              });
+              Ok(handles)
+            },
+            Err(e) =>  Err(Error::msg("cannot get payment event handles"))
+        }
+    }
+
+    pub fn get_events(
+        &mut self,
+        event_key: &EventKey,
+        start: u64,
+        limit: u64,
+    ) -> Result<Vec<EventView>> {
+        let key = hex::encode(event_key.as_bytes());
+        
+        self.client.get_events(key, start, limit)
+    }
+
+    pub fn get_handle_events(&mut self, event_handle: &EventHandle) -> Result<Vec<EventView>> {
+        if event_handle.count() == 0 {
+            return Ok(vec![]);
+        }
+        self.get_events(
+          event_handle.key(), 
+          0, 
+          event_handle.count()
+        )
     }
 }
 

--- a/ol/cli/src/node/account.rs
+++ b/ol/cli/src/node/account.rs
@@ -106,6 +106,7 @@ impl Node {
         }
     }
 
+    /// Get event handles associated with payments
     pub fn get_payment_event_handles(
         &mut self,
         account: AccountAddress,
@@ -122,10 +123,11 @@ impl Node {
               });
               Ok(handles)
             },
-            Err(e) =>  Err(Error::msg("cannot get payment event handles"))
+            Err(_) =>  Err(Error::msg("cannot get payment event handles"))
         }
     }
 
+    /// Get events associated with an event handle's key
     pub fn get_events(
         &mut self,
         event_key: &EventKey,
@@ -137,6 +139,8 @@ impl Node {
         self.client.get_events(key, start, limit)
     }
 
+    /// get all events associated with an EventHandle
+    // change this to async and do paging.
     pub fn get_handle_events(&mut self, event_handle: &EventHandle) -> Result<Vec<EventView>> {
         if event_handle.count() == 0 {
             return Ok(vec![]);

--- a/ol/cli/src/node/account.rs
+++ b/ol/cli/src/node/account.rs
@@ -141,13 +141,14 @@ impl Node {
 
     /// get all events associated with an EventHandle
     // change this to async and do paging.
-    pub fn get_handle_events(&mut self, event_handle: &EventHandle) -> Result<Vec<EventView>> {
+    pub fn get_handle_events(&mut self, event_handle: &EventHandle, seq_start: Option<u64>) -> Result<Vec<EventView>> {
         if event_handle.count() == 0 {
             return Ok(vec![]);
         }
+        // TODO: how to get the highest sequence number available in the database.
         self.get_events(
           event_handle.key(), 
-          0, 
+          seq_start.unwrap_or(0), 
           event_handle.count()
         )
     }

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -1,7 +1,8 @@
 //! 'query'
 use std::collections::BTreeMap;
 
-use libra_json_rpc_client::{views::TransactionView, AccountAddress};
+use hex::decode;
+use libra_json_rpc_client::{AccountAddress, views::{BytesView, EventView, TransactionView}};
 use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
@@ -9,6 +10,8 @@ use move_core_types::{
 use num_format::{Locale, ToFormattedString};
 use resource_viewer::{AnnotatedAccountStateBlob, AnnotatedMoveStruct, AnnotatedMoveValue};
 use super::node::Node;
+
+const SCALING_FACTOR: u64 = 1_000_000;
 
 #[derive(Debug)]
 /// What query do we want to return
@@ -68,12 +71,11 @@ impl Node {
         match query_type {
             Balance { account } => {
                 // TODO: get scaling factor from chain.
-                let scaling_factor = 1_000_000;
                 match self.client.get_account(account, true) {
                     Ok((Some(account_view), _)) => {
                         for av in account_view.balances.iter() {
                             if av.currency == "GAS" {
-                                let amount = av.amount / scaling_factor;
+                                let amount = av.amount / SCALING_FACTOR;
                                 return amount.to_formatted_string(&Locale::en);
                             }
                         }
@@ -172,12 +174,13 @@ impl Node {
             .get_payment_event_handles(account)
             .unwrap();
 
+            
             if let Some((sent_handle, received_handle)) = handles {
                   for evt in self.get_handle_events(&sent_handle).unwrap() {
-                    if sent_or_received { print.push_str(&format!("{:?}\n", evt)); }
+                    if sent_or_received { print.push_str(&format_event_view(evt)) }
                   }
                   for evt in self.get_handle_events(&received_handle).unwrap() {
-                    if !sent_or_received { print.push_str(&format!("{:?}\n", evt)); }
+                    if !sent_or_received { print.push_str(&format_event_view(evt)) }
                   }
               };
             print
@@ -187,7 +190,30 @@ impl Node {
 }
 
 
+fn format_event_view(e: EventView) -> String {
 
+  // TODO: make this more idiomatic.
+
+  use libra_json_rpc_client::views::EventDataView::*;
+  let (a, BytesView(s), BytesView(r), BytesView(m), ..) = match e.data {
+    ReceivedPayment { amount, sender, receiver, metadata } => {
+      (amount, sender, receiver,  metadata)
+    },
+    SentPayment { amount, receiver, sender, metadata } => {
+      (amount, sender, receiver,  metadata)
+    },
+    _ => { panic!("trying to parse a payment event type, but event is not a ReceivedPayment or SentPayment")}
+  };
+  let scaled = a.amount / SCALING_FACTOR;
+  format!(
+    "id: {:?}, sender: {:?}, recipient: {:?}, amount: {:?}, metadata: {:?}\n",
+    e.sequence_number,
+    s,
+    r,
+    scaled.to_formatted_string(&Locale::en),
+    String::from_utf8_lossy(&decode(m).unwrap()),
+  )
+}
 
 /// check if the vec of value, is actually of other structs
 pub fn is_vec_of_struct(

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -60,6 +60,8 @@ pub enum QueryType {
       account: AccountAddress,
       /// switch for sent or received events.
       sent_or_received: bool,
+      /// what event sequence number to start querying from, if DB does not have all.
+      seq_start: Option<u64>,
     }
 }
 
@@ -166,7 +168,8 @@ impl Node {
           },
           Events {
             account,
-            sent_or_received
+            sent_or_received,
+            seq_start,
           } => {
             // TODO: should borrow and not create a new client.
             let mut print = "Events \n".to_string();
@@ -176,10 +179,10 @@ impl Node {
 
             
             if let Some((sent_handle, received_handle)) = handles {
-                  for evt in self.get_handle_events(&sent_handle).unwrap() {
+                  for evt in self.get_handle_events(&sent_handle, seq_start).unwrap() {
                     if sent_or_received { print.push_str(&format_event_view(evt)) }
                   }
-                  for evt in self.get_handle_events(&received_handle).unwrap() {
+                  for evt in self.get_handle_events(&received_handle, seq_start).unwrap() {
                     if !sent_or_received { print.push_str(&format_event_view(evt)) }
                   }
               };

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -1,7 +1,6 @@
 //! 'query'
 use std::collections::BTreeMap;
 
-use cli::libra_client::LibraClient;
 use libra_json_rpc_client::{views::TransactionView, AccountAddress};
 use move_core_types::{
     identifier::Identifier,
@@ -9,9 +8,6 @@ use move_core_types::{
 };
 use num_format::{Locale, ToFormattedString};
 use resource_viewer::{AnnotatedAccountStateBlob, AnnotatedMoveStruct, AnnotatedMoveValue};
-
-use crate::{events::EventsFetcher, node::client};
-
 use super::node::Node;
 
 #[derive(Debug)]
@@ -57,6 +53,7 @@ pub enum QueryType {
     },
     /// Get events
     Events {
+      /// account to query events
       account: AccountAddress
     }
 }

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -54,7 +54,9 @@ pub enum QueryType {
     /// Get events
     Events {
       /// account to query events
-      account: AccountAddress
+      account: AccountAddress,
+      /// switch for sent or received events.
+      sent_or_received: bool,
     }
 }
 
@@ -161,7 +163,8 @@ impl Node {
                 }
           },
           Events {
-            account
+            account,
+            sent_or_received
           } => {
             // TODO: should borrow and not create a new client.
             let mut print = "Events \n".to_string();
@@ -171,10 +174,10 @@ impl Node {
 
             if let Some((sent_handle, received_handle)) = handles {
                   for evt in self.get_handle_events(&sent_handle).unwrap() {
-                    print.push_str(&format!("{:?}", evt));
+                    if sent_or_received { print.push_str(&format!("{:?}\n", evt)); }
                   }
                   for evt in self.get_handle_events(&received_handle).unwrap() {
-                    print.push_str(&format!("{:?}", evt));
+                    if !sent_or_received { print.push_str(&format!("{:?}\n", evt)); }
                   }
               };
             print


### PR DESCRIPTION
Adds ability of `ol cli` to query events. E.g. to query for sent and received payments.

use with : 

```
// your account
ol query --events-sent
ol query --events-received

// any account
ol --account <account> query --events-sent

// if you don't have all sequence numbers in db, start from a certain sequence number / transaction height
ol query --events-sent --txs-height 100
```