### PR TITLE
TXS timeout and error handling

### DIFF
--- a/ol/integration-tests/test-upgrade.mk
+++ b/ol/integration-tests/test-upgrade.mk
@@ -124,7 +124,7 @@ progress:
 				exit 1 ; \
 			fi ; \
 			echo "Sleeping for 1 min" ; \
-			sleep 1m ; \
+			sleep 10 ; \
 	done
 
 tail:

--- a/ol/integration-tests/test-upgrade.mk
+++ b/ol/integration-tests/test-upgrade.mk
@@ -124,7 +124,7 @@ progress:
 				exit 1 ; \
 			fi ; \
 			echo "Sleeping for 1 min" ; \
-			sleep 10 ; \
+			sleep 1m ; \
 	done
 
 tail:

--- a/ol/txs/src/commands/autopay_cmd.rs
+++ b/ol/txs/src/commands/autopay_cmd.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::never_loop)]
 
+use std::process::exit;
+
 use abscissa_core::{Command, Options, Runnable};
 
 use crate::{entrypoint, submit_tx::{ maybe_submit, tx_params_wrapper}};
@@ -30,12 +32,19 @@ impl Runnable for AutopayCmd {
         } else {
           panic!("must choose --enable or --disable");
         };
-        maybe_submit(
+        
+        match maybe_submit(
           script,
           &tx_params,
           entry_args.no_send,
           entry_args.save_path,
-        ).unwrap();
+        ) {
+            Err(e) => {
+              println!("ERROR: could not submit autopay transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
             
 
 

--- a/ol/txs/src/commands/create_account_cmd.rs
+++ b/ol/txs/src/commands/create_account_cmd.rs
@@ -6,7 +6,7 @@ use abscissa_core::{Command, Options, Runnable};
 use ol_types::config::TxType;
 use crate::{entrypoint, submit_tx::{tx_params_wrapper, maybe_submit}};
 use libra_types::{transaction::{Script}};
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, process::exit};
 
 /// `CreateAccount` subcommand
 #[derive(Command, Debug, Default, Options)]
@@ -44,20 +44,18 @@ impl Runnable for CreateAccountCmd {
         let entry_args = entrypoint::get_args();
         let account_json = self.account_json_path.to_str().unwrap();
         let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
-        maybe_submit(
+        
+        match maybe_submit(
           create_user_account_script(account_json),
           &tx_params,
           entry_args.no_send,
           entry_args.save_path,
-        ).unwrap();
-        // match submit_tx(
-        //     &tx_params, 
-        //     create_user_account_script(account_json)
-        // ) {
-        //     Err(err) => { println!("{:?}", err) }
-        //     Ok(res)  => {
-        //         eval_tx_status(res);
-        //     }
-        // }
+        ) {
+            Err(e) => {
+              println!("ERROR: could not submit account creation transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
     }
 }

--- a/ol/txs/src/commands/demo_cmd.rs
+++ b/ol/txs/src/commands/demo_cmd.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::never_loop)]
 
+use std::process::exit;
+
 use abscissa_core::{Command, Options, Runnable};
 use ol_types::config::TxType;
 use crate::{entrypoint, submit_tx::{tx_params_wrapper, maybe_submit}};
@@ -16,11 +18,20 @@ impl Runnable for DemoCmd {
         let entry_args = entrypoint::get_args();
 
         let tx_params = tx_params_wrapper(TxType::Cheap).unwrap();
-        maybe_submit(
+
+        match maybe_submit(
           transaction_builder::encode_demo_e2e_script(42),
           &tx_params,
           entry_args.no_send,
           entry_args.save_path
-        ).unwrap();
+        ) {
+            Ok(r) => {
+              println!("{:?}", &r);
+            },
+            Err(e) => {
+              println!("ERROR: could not submit demo transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+        }
     }
 }

--- a/ol/txs/src/commands/oracle_upgrade_cmd.rs
+++ b/ol/txs/src/commands/oracle_upgrade_cmd.rs
@@ -6,7 +6,7 @@ use abscissa_core::{Command, Options, Runnable};
 use ol_types::config::TxType;
 use crate::{entrypoint, prelude::app_config, submit_tx::{tx_params_wrapper, maybe_submit}};
 use libra_types::{transaction::{Script}};
-use std::{fs, io::prelude::*, path::PathBuf};
+use std::{fs, io::prelude::*, path::PathBuf, process::exit};
 
 /// `OracleUpgrade` subcommand
 #[derive(Command, Debug, Default, Options)]
@@ -35,11 +35,17 @@ impl Runnable for OracleUpgradeCmd {
           cfg.workspace.stdlib_bin_path.clone().unwrap()
         });
         
-        maybe_submit(
+        match maybe_submit(
           oracle_tx_script(&path),
           &tx_params,
           entry_args.no_send,
           entry_args.save_path
-        ).unwrap();
+        ) {
+            Err(e) => {
+              println!("ERROR: could not submit upgrade transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
     }
 }

--- a/ol/txs/src/commands/relay_cmd.rs
+++ b/ol/txs/src/commands/relay_cmd.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::never_loop)]
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
 
 use abscissa_core::{Command, Options, Runnable};
 use crate::relay::relay_from_file;
@@ -18,6 +18,12 @@ pub struct RelayCmd {
 
 impl Runnable for RelayCmd {    
     fn run(&self) {
-        relay_from_file(self.relay_file.clone()).unwrap();
+        match relay_from_file(self.relay_file.clone()) {
+            Err(e) => {
+              println!("ERROR: could not relay transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
     }
 }

--- a/ol/txs/src/commands/valset_cmd.rs
+++ b/ol/txs/src/commands/valset_cmd.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::never_loop)]
 
+use std::process::exit;
+
 use crate::{
     entrypoint,
     submit_tx::{maybe_submit, tx_params_wrapper},
@@ -37,13 +39,18 @@ impl Runnable for ValSetCmd {
           panic!("need to set --join or --leave flags")
         };
 
-        maybe_submit(
+        match maybe_submit(
             script,
             // transaction_builder::encode_demo_e2e_script(42),
             &tx_params,
             entry_args.no_send,
             entry_args.save_path,
-        )
-        .unwrap();
+        ) {
+            Err(e) => {
+              println!("ERROR: could not submit validator-set transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
     }
 }

--- a/ol/txs/src/commands/wallet_cmd.rs
+++ b/ol/txs/src/commands/wallet_cmd.rs
@@ -32,11 +32,17 @@ impl Runnable for WalletCmd {
         };
 
         let tx_params = tx_params_wrapper(TxType::Cheap).unwrap();
-        maybe_submit(
+        match maybe_submit(
           transaction_builder::encode_set_wallet_type_script(type_int),
           &tx_params,
           entry_args.no_send,
           entry_args.save_path
-        ).unwrap();
+        ) {
+            Err(e) => {
+              println!("ERROR: could not submit wallet type transaction, message: \n{:?}", &e);
+              exit(1);
+            },
+            _ => {}
+        }
     }
 }

--- a/ol/txs/src/submit_tx.rs
+++ b/ol/txs/src/submit_tx.rs
@@ -384,15 +384,16 @@ pub fn wait_for_tx(
     client: &mut LibraClient,
 ) -> Option<TransactionView> {
     println!(
-        "\nAwaiting tx status \n\
-       Submitted from account: {} with sequence number: {}",
-        signer_address, sequence_number
+      "\nAwaiting tx status \nSubmitted from account: {} with sequence number: {}",
+      signer_address,
+      sequence_number
     );
 
+    const MAX_ITERATIONS: u8 = 30;
+
     let mut iter = 0;
-    const MAX_ITERATIONS: u8 = 10; // 5000 * 2/1000
     loop {
-        thread::sleep(time::Duration::from_millis(1000));
+        thread::sleep(time::Duration::from_millis(1_000));
         // prevent all the logging the client does while
         // it loops through the query.
         stdout().flush().unwrap();
@@ -411,6 +412,7 @@ pub fn wait_for_tx(
         iter += 1;
 
         if iter==MAX_ITERATIONS {
+            println!("Timeout waiting for response");
             return None;
         }
     }


### PR DESCRIPTION
TXS app was timing-out on certain integration tests. The issue was that the time-out was set to 10 secs which is too low. Additionally, many TXS subcommands did not have error handling, and would instead panic, which made it hard to debug.

- [x] longer timeouts in txs::submit_tx
- [x] better error handling in txs app.