### PR TITLE
added autopay and fail-safe behaviour to swarm documentation

### DIFF
--- a/ol/documentation/devs/swarm_qa_tools.md
+++ b/ol/documentation/devs/swarm_qa_tools.md
@@ -192,7 +192,7 @@ cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob relay --rel
 
 When you experiment with swarm and the autopay feature, be aware that there is a "fail-safe" built into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
 
-In the "real world", a validator node which has no autopay and operator configs set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
+In the "real world", a validator node which has no autopay and operator configs set up will be thrown out of the validator set, but in swarm, as no node has and operator configs set up per default, no node will be thrown out.
 
 We've debated putting a switch to have a different behavior in testnet mode, but even that felt like not "fail safe" behavior.
 

--- a/ol/documentation/devs/swarm_qa_tools.md
+++ b/ol/documentation/devs/swarm_qa_tools.md
@@ -190,7 +190,7 @@ cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob relay --rel
 
 ### swarm and autopay transactions
 
-When you experiment with swarm and the autopay feature, be aware that there is a "fail-save" build into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
+When you experiment with swarm and the autopay feature, be aware that there is a "fail-save" built into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
 
 In the "real world", a validator node which has no autopay set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
 

--- a/ol/documentation/devs/swarm_qa_tools.md
+++ b/ol/documentation/devs/swarm_qa_tools.md
@@ -190,9 +190,9 @@ cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob relay --rel
 
 ### swarm and autopay transactions
 
-When you experiment with swarm and the autopay feature, be aware that there is a "fail-save" built into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
+When you experiment with swarm and the autopay feature, be aware that there is a "fail-safe" built into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
 
-In the "real world", a validator node which has no autopay set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
+In the "real world", a validator node which has no autopay and operator configs set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
 
 We've debated putting a switch to have a different behavior in testnet mode, but even that felt like not "fail safe" behavior.
 

--- a/ol/documentation/devs/swarm_qa_tools.md
+++ b/ol/documentation/devs/swarm_qa_tools.md
@@ -190,7 +190,7 @@ cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob relay --rel
 
 ### swarm and autopay transactions
 
-When you expermiment with swarm and the autopay feature, be aware that there is a "fail-save" build into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
+When you experiment with swarm and the autopay feature, be aware that there is a "fail-save" build into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
 
 In the "real world", a validator node which has no autopay set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
 

--- a/ol/documentation/devs/swarm_qa_tools.md
+++ b/ol/documentation/devs/swarm_qa_tools.md
@@ -187,3 +187,23 @@ cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob --save-path
 cd $HOME/libra
 cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=bob relay --relay-file ./noop_tx.json
 ```
+
+### swarm and autopay transactions
+
+When you expermiment with swarm and the autopay feature, be aware that there is a "fail-save" build into the validator set election. If we don't get 4 validators who qualify to be in the validator set, then the system does not change the validator set. So often in swarm for dev purposes we will have 4 or fewer nodes, so we don't get an accurate picture of the reconfiguration.
+
+In the "real world", a validator node which has no autopay set up will be thrown out of the validator set, but in swarm, as no node has autopay set up per default, no node will be thrown out.
+
+We've debated putting a switch to have a different behavior in testnet mode, but even that felt like not "fail safe" behavior.
+
+#### set autopay for `alice`
+```
+cd $HOME/libra
+cargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=alice autopay-batch -f ol/fixtures/autopay/alice.autopay_batch.json
+```
+
+#### stop autopay for `alice`
+```
+cd $HOME/libracargo r -p txs -- --swarm-path=$HOME/swarm_temp/ --swarm-persona=alice autopay --disable
+```
+


### PR DESCRIPTION
## Motivation

As discussed in our discord channel it would be helpful if the "fail-save" behaviour of validator selection is described in context of swarm and autopay.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

This PR only covers documentation update. Please check the updated section at the end of the documentation if it is o.k.

