### PR TITLE
CLI prevent unreachable sync state height from making the cli panic

### DIFF
--- a/ol/cli/src/node/sync.rs
+++ b/ol/cli/src/node/sync.rs
@@ -46,7 +46,10 @@ impl Node {
             .expect("cannot connect to upstream node");
 
         if let Some(local_db) = self.get_db_state() {
-            s.remote_height = remote_client.get_metadata().unwrap().version;
+            s.remote_height = match remote_client.get_metadata(){
+                Ok(m) => m.version,
+                Err(_) => 404,
+            };
             s.sync_height = local_db.synced_version;
             s.sync_delay = s.remote_height as i64 - s.sync_height as i64;
             s.is_synced = s.sync_delay < 1000;

--- a/ol/documentation/cli_cheatsheet.md
+++ b/ol/documentation/cli_cheatsheet.md
@@ -1,0 +1,12 @@
+# Common CLI Commands
+
+
+### Get Payment Events Received
+account: the address to query.
+events-received: a bool, to check incoming txs.
+txs-height: Starting event number/nonce. Note: Not all nodes will have the full event list in database. e.g. those nodes restoring from an epoch archive.
+
+For example querying the iqlusion Engineering program:
+```
+ol --account c906f67f626683b77145d1f20c1a753b query --events-received --txs-height 10
+```


### PR DESCRIPTION
CLI commands such as `ol start` might crash if an upstream node cannot be reached (e.g. to get a block height reference). This patch handles that error.