### PR TITLE
Genesis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ wipe:
 	srm ~/.bash_history
 
 stop:
-	service diem-node stop
+	systemctl --user stop diem-node.service
 
 debug:
 	make smoke-onboard <<< $$'${MNEM}'

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -303,7 +303,7 @@ where
                     .collect(),
                 &proof_reader,
             )
-            .expect("Failed to update state tree.");
+            .map_err(|e| format_err!("Failed to update state tree. err: {:?}", e))?;
 
         for ((vm_output, txn), (state_tree_hash, blobs)) in itertools::zip_eq(
             itertools::zip_eq(vm_outputs.into_iter(), transactions.iter()).take(transaction_count),

--- a/ol/cli/src/commands/start_cmd.rs
+++ b/ol/cli/src/commands/start_cmd.rs
@@ -42,8 +42,14 @@ impl Runnable for StartCmd {
         if *&self.refresh_upstream {
             // fix 0L.toml file
             let cfg_path = cfg.workspace.node_home;
-            node.refresh_peers_update_toml(cfg_path.join("0L.toml")).ok();
-            return
+            match node.refresh_peers_update_toml(cfg_path.join("0L.toml")) {
+                Ok(_) => return,
+                Err(e) => {
+                  println!("ERROR: unable to update seed peers, message:{:?}", e);
+                  exit(1);
+                },
+            };
+            
         };
         if *&self.restore { pilot::maybe_restore_db(&mut node, !self.silent); }
         check::runner::run_checks(&mut node, true ,true, !self.silent, !self.silent);

--- a/ol/cli/src/node/refresh_peers.rs
+++ b/ol/cli/src/node/refresh_peers.rs
@@ -16,7 +16,7 @@ impl Node {
 
         let url_list: Vec<Url>;
 
-        match &self.vitals.chain_view {
+        match &self.refresh_chain_info().0 {
             Some(v) => {
                 url_list = v
                     .validator_view
@@ -31,6 +31,7 @@ impl Node {
                         let mut u = Url::parse("http://localhost").unwrap();
                         u.set_ip_host(a).ok();
                         u.set_port(Some(8080)).ok();
+                        dbg!(&u);
                         Some(u)
                     })
                     .collect();


### PR DESCRIPTION
Patches from genesis

- [x] handle error in state tree execution: https://github.com/diem/diem/blob/26b6aa817755fc07c6da4f64e53ca2555d061f6e/execution/executor/src/lib.rs#L311
- [x] ol start --refresh-upstream fixed
- [x] makefile for daemon