### PR TITLE
fix for #769, tower command not respecting 0L.toml settings

### DIFF
--- a/ol/tower/src/commit_proof.rs
+++ b/ol/tower/src/commit_proof.rs
@@ -5,9 +5,11 @@ use cli::{diem_client::DiemClient, AccountData, AccountStatus};
 use txs::{sign_tx::sign_tx, submit_tx::{TxParams, submit_tx}};
 use diem_json_rpc_types::views::{TransactionView};
 use diem_transaction_builder::stdlib as transaction_builder;
+use reqwest::Url;
 
 /// Submit a miner transaction to the network.
 pub fn commit_proof_tx(
+    upstream_url: &Url,
     tx_params: &TxParams,
     preimage: Vec<u8>,
     proof: Vec<u8>,
@@ -15,7 +17,7 @@ pub fn commit_proof_tx(
 ) -> Result<TransactionView, Error> {
 
     // Create a client object
-    let client = DiemClient::new(tx_params.url.clone(), tx_params.waypoint).unwrap();
+    let client = DiemClient::new(upstream_url.clone(), tx_params.waypoint).unwrap();
 
     let chain_id = tx_params.chain_id;
 


### PR DESCRIPTION
## Motivation

tower app was not respectingh default_node setting in 0L.toml

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

I tested it on swarm. When setting upstream url of "bob" in 0L.toml of alice as default_node, the tower command's output shows bob's node as target for fetching remote tower state and also for committing proofs


## Related Issue:

https://github.com/OLSF/libra/issues/769

