### PR TITLE
replaced links pointing to wiki by links to corresponding documentation in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ### A reference implementation of a neutral replicated state machine
 
 
-Join a network with a [validator node](https://github.com/OLSF/libra/wiki/Validator-Onboarding-Guide:-Easy-Mode), to secure the state machine.
+Join a network with a [validator node](https://github.com/OLSF/libra/blob/main/ol/documentation/ops/validator_onboarding_guide_easy_mode.md), to secure the state machine.
 
-Run a [fullnode](https://github.com/OLSF/libra/wiki/Mining-VDF-Proofs), to keep a copy of the state machine.
+Run a [fullnode](https://github.com/OLSF/libra/blob/main/ol/documentation/ops/mining_VDF_proofs.md), to keep a copy of the state machine.
 
 Contribute to [issues](https://github.com/OLSF/libra/issues).
 

--- a/language/testing-infra/e2e-tests/src/ol_oracle_setup.rs
+++ b/language/testing-infra/e2e-tests/src/ol_oracle_setup.rs
@@ -26,7 +26,7 @@ pub fn oracle_helper_tx(
 }
 
 // Generated temporarily and copied from `sdk/transaction-builder/src/stdlib.rs`
-// See https://github.com/OLSF/libra/wiki/Stdlib-Upgrade-payload-(v5)
+// See https://github.com/OLSF/libra/blob/main/ol/documentation/ops/stdlib_upgrade_payload.md
 pub fn encode_ol_oracle_upgrade_foo_tx_script_function() -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(

--- a/ol/cli/web-monitor/public/build/bundle.js
+++ b/ol/cli/web-monitor/public/build/bundle.js
@@ -19266,7 +19266,7 @@ var app = (function () {
     			attr_dev(span, "uk-icon", "icon: info");
     			add_location(span, file$b, 1, 4, 170);
     			attr_dev(a, "target", "_blank");
-    			attr_dev(a, "href", "https://github.com/OLSF/libra/wiki/How-to-Config-Web-Monitor-Account-Dictionary");
+    			attr_dev(a, "href", "https://github.com/OLSF/libra/blob/main/ol/documentation/ops/web_monitor_account_dictionary.md");
     			attr_dev(a, "uk-tooltip", "click and learn how to add notes to addresses");
     			add_location(a, file$b, 0, 0, 0);
     		},

--- a/ol/cli/web-monitor/src/components/address/AddressNoteTip.svelte
+++ b/ol/cli/web-monitor/src/components/address/AddressNoteTip.svelte
@@ -1,3 +1,3 @@
-<a target="_blank" href="https://github.com/OLSF/libra/wiki/How-to-Config-Web-Monitor-Account-Dictionary" uk-tooltip="click and learn how to add notes to addresses">
+<a target="_blank" href="https://github.com/OLSF/libra/blob/main/ol/documentation/ops/web_monitor_account_dictionary.md">
     <span uk-icon="icon: info"></span>
 </a>

--- a/ol/documentation/devs/testing_chain_upgrades.md
+++ b/ol/documentation/devs/testing_chain_upgrades.md
@@ -2,9 +2,7 @@
 
 How to test Chain upgrades locally with swarm.
 
-In depth on starting swarm: https://github.com/OLSF/libra/wiki/Start-a-network-locally-(libra-swarm)
-Instructions on using 0L tooling with swarm: [https://github.com/OLSF/libra/wiki/QA-0L-tools-using-Swarm]
-
+In depth on starting swarm: (swarm_qa_tools.md)
 
 # Prepare Env
 ## Pull the previous version

--- a/ol/documentation/ops/archived/v4.3.0_upgrade.md
+++ b/ol/documentation/ops/archived/v4.3.0_upgrade.md
@@ -14,7 +14,7 @@ This is a Chain upgrade only (Move stdlib). Node upgrades will follow with v4.3.
 ```
 
 ## Summary
-This is a minor upgrade due to changes in stdlib, some which break apis, see semantics: https://github.com/OLSF/libra/wiki/Versioning-Semantics
+This is a minor upgrade due to changes in stdlib, some which break apis, see semantics: (../../devs/versioning_semantics.md)
 
 As such Part 1 will be the voting and upgrading of stdlib. And Part 2 will be upgrading tooling.
 


### PR DESCRIPTION
## Motivation

As prerequisite for removing the "wiki" section, all links pointing there are now replaced by links pointing to the corresponding documents in the ol/documentation folder in the repository.

Enhancing README.md will be a separate PR.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Besides documentation update, this PR contains a software change of web monitor. The link within the info-icon now points to https://github.com/OLSF/libra/blob/main/ol/documentation/ops/web_monitor_account_dictionary.md 
