### PR TITLE
Patch validator upgrade

### DIFF
--- a/language/move-lang/functional-tests/tests/0L/diem_account/unhosted_account_with_coin.move
+++ b/language/move-lang/functional-tests/tests/0L/diem_account/unhosted_account_with_coin.move
@@ -1,0 +1,29 @@
+//! account: bob, 10000000, 0, validator
+
+//! new-transaction
+//! sender: bob
+script {
+  use 0x1::DiemAccount;
+  use 0x1::GAS::GAS;
+
+  fun main(sender: signer) {
+    // Eve's account info.
+
+    let new_account: address = @0x3DC18D1CF61FAAC6AC70E3A63F062E4B;
+    let new_account_authkey_prefix = x"2bffcbd0e9016013cb8ca78459f69d2b";
+    let value = 1000000; // minimum is 1m microgas
+
+    let eve_addr = DiemAccount::create_user_account_with_coin(
+      &sender,
+      new_account,
+      new_account_authkey_prefix,
+      value,
+    );
+
+    assert(DiemAccount::balance<GAS>(eve_addr) == 1000000, 735701);
+
+    // is NOT a slow wallet
+    assert(!DiemAccount::is_slow(eve_addr), 735702);
+  }
+}
+// check: EXECUTED

--- a/language/move-lang/functional-tests/tests/0L/diem_account/upgrade_to_validator_from_coin.move
+++ b/language/move-lang/functional-tests/tests/0L/diem_account/upgrade_to_validator_from_coin.move
@@ -1,0 +1,112 @@
+
+
+//! account: bob, 10000000, 0, validator
+
+//! new-transaction
+//! sender: bob
+script {
+  use 0x1::DiemAccount;
+  use 0x1::TestFixtures;
+  use 0x1::GAS::GAS;
+
+  fun main(sender: signer) {
+    // Eve's account info.
+
+    let new_account: address = @0x3DC18D1CF61FAAC6AC70E3A63F062E4B;
+    let new_account_authkey_prefix = x"2bffcbd0e9016013cb8ca78459f69d2b";
+    let value = 1000000; // minimum is 1m microgas
+
+    let eve_addr = DiemAccount::create_user_account_with_coin(
+      &sender,
+      new_account,
+      new_account_authkey_prefix,
+      value,
+    );
+
+    assert(DiemAccount::balance<GAS>(eve_addr) == 1000000, 735701);
+
+    // is NOT a slow wallet
+    assert(!DiemAccount::is_slow(eve_addr), 735702);
+  }
+}
+// check: EXECUTED
+
+
+// //! new-transaction
+// //! sender: bob
+// script {
+// // use 0x1::VDF;
+// use 0x1::DiemAccount;
+// // use 0x1::TowerState;
+// use 0x1::TestFixtures;
+// // use 0x1::Vector;
+
+
+// // Test Prefix: 1301
+// fun main(sender: signer) {
+//   // Scenario: Bob, an existing validator, is sending a transaction for Eve, 
+//   // with a challenge and proof not yet submitted to the chain.
+//   let challenge = TestFixtures::eve_0_easy_chal();
+//   let solution = TestFixtures::eve_0_easy_sol();
+//   // // Parse key and check
+//   // let (eve_addr, _auth_key) = VDF::extract_address_from_challenge(&challenge);
+//   // assert(eve_addr == @0x3DC18D1CF61FAAC6AC70E3A63F062E4B, 7357401001);
+  
+//   // let epochs_since_creation = 10;
+//   // TowerState::test_helper_set_rate_limit(&sender, epochs_since_creation);
+
+//   DiemAccount::create_validator_account_with_proof(
+//       &sender,
+//       &challenge,
+//       &solution,
+//       TestFixtures::easy_difficulty(), // difficulty
+//       TestFixtures::security(), // security
+//       b"leet",
+//       @0xfa72817f1b5aab94658238ddcdc08010,
+//       x"fa72817f1b5aab94658238ddcdc08010",
+//       // random consensus_pubkey: vector<u8>,
+//       x"8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010", 
+//       b"192.168.0.1", // validator_network_addresses: vector<u8>,
+//       b"192.168.0.1", // fullnode_network_addresses: vector<u8>,
+//       x"1ee7", // human_name: vector<u8>,
+//   );
+
+//   // the prospective validator is in the current miner list.
+//   // assert(Vector::contains<address>(&TowerState::get_miner_list(), &eve_addr), 7357401002);
+// }
+// }
+// // check: EXECUTED
+
+
+
+// //! new-transaction
+// //! sender: diemroot
+// script {
+// use 0x1::EpochBoundary;
+// use 0x1::DiemAccount;
+// use 0x1::GAS::GAS;
+// use 0x1::ValidatorUniverse;
+// use 0x1::ValidatorConfig;
+
+// fun main(vm: signer) {
+//   let eve_addr = @0x3DC18D1CF61FAAC6AC70E3A63F062E4B;
+//   /// set the fullnode proof price to 0, to check if onboarding subsidy is given.
+//   // FullnodeSubsidy::test_set_fullnode_fixtures(&vm, 0, 0, 0, 0, 0);
+//   EpochBoundary::reconfigure(&vm, 10); 
+//     // need to remove testnet for this test, since testnet does not ratelimit 
+//     // account creation.
+//   let oper_eve = ValidatorConfig::get_operator(eve_addr);
+//   let bal = DiemAccount::balance<GAS>(oper_eve);
+//   // we expect 1 gas (1,000,000 microgas) from bob's transfer
+//   assert(bal == 1000000, 7357401003);
+
+//   // validator should have jailedbit
+//   assert(ValidatorUniverse::exists_jailedbit(eve_addr), 7357401004);
+//   // validator should be in universe if just joined.
+//   assert(ValidatorUniverse::is_in_universe(eve_addr), 7357401005);
+//   // should not be jailed
+//   assert(!ValidatorUniverse::is_jailed(eve_addr), 7357401006);
+//   // is a slow wallet
+//   assert(DiemAccount::is_slow(eve_addr), 7357401007);
+// }
+// }

--- a/language/move-lang/functional-tests/tests/0L/diem_account/upgrade_to_validator_from_coin.move
+++ b/language/move-lang/functional-tests/tests/0L/diem_account/upgrade_to_validator_from_coin.move
@@ -1,12 +1,9 @@
-
-
 //! account: bob, 10000000, 0, validator
 
 //! new-transaction
 //! sender: bob
 script {
   use 0x1::DiemAccount;
-  use 0x1::TestFixtures;
   use 0x1::GAS::GAS;
 
   fun main(sender: signer) {
@@ -32,50 +29,50 @@ script {
 // check: EXECUTED
 
 
-// //! new-transaction
-// //! sender: bob
-// script {
-// // use 0x1::VDF;
-// use 0x1::DiemAccount;
-// // use 0x1::TowerState;
-// use 0x1::TestFixtures;
-// // use 0x1::Vector;
+//! new-transaction
+//! sender: bob
+script {
+// use 0x1::VDF;
+use 0x1::DiemAccount;
+// use 0x1::TowerState;
+use 0x1::TestFixtures;
+// use 0x1::Vector;
 
 
-// // Test Prefix: 1301
-// fun main(sender: signer) {
-//   // Scenario: Bob, an existing validator, is sending a transaction for Eve, 
-//   // with a challenge and proof not yet submitted to the chain.
-//   let challenge = TestFixtures::eve_0_easy_chal();
-//   let solution = TestFixtures::eve_0_easy_sol();
-//   // // Parse key and check
-//   // let (eve_addr, _auth_key) = VDF::extract_address_from_challenge(&challenge);
-//   // assert(eve_addr == @0x3DC18D1CF61FAAC6AC70E3A63F062E4B, 7357401001);
+// Test Prefix: 1301
+fun main(sender: signer) {
+  // Scenario: Bob, an existing validator, is sending a transaction for Eve, 
+  // with a challenge and proof not yet submitted to the chain.
+  let challenge = TestFixtures::eve_0_easy_chal();
+  let solution = TestFixtures::eve_0_easy_sol();
+  // // Parse key and check
+  // let (eve_addr, _auth_key) = VDF::extract_address_from_challenge(&challenge);
+  // assert(eve_addr == @0x3DC18D1CF61FAAC6AC70E3A63F062E4B, 7357401001);
   
-//   // let epochs_since_creation = 10;
-//   // TowerState::test_helper_set_rate_limit(&sender, epochs_since_creation);
+  // let epochs_since_creation = 10;
+  // TowerState::test_helper_set_rate_limit(&sender, epochs_since_creation);
 
-//   DiemAccount::create_validator_account_with_proof(
-//       &sender,
-//       &challenge,
-//       &solution,
-//       TestFixtures::easy_difficulty(), // difficulty
-//       TestFixtures::security(), // security
-//       b"leet",
-//       @0xfa72817f1b5aab94658238ddcdc08010,
-//       x"fa72817f1b5aab94658238ddcdc08010",
-//       // random consensus_pubkey: vector<u8>,
-//       x"8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010", 
-//       b"192.168.0.1", // validator_network_addresses: vector<u8>,
-//       b"192.168.0.1", // fullnode_network_addresses: vector<u8>,
-//       x"1ee7", // human_name: vector<u8>,
-//   );
+  DiemAccount::create_validator_account_with_proof(
+      &sender,
+      &challenge,
+      &solution,
+      TestFixtures::easy_difficulty(), // difficulty
+      TestFixtures::security(), // security
+      b"leet",
+      @0xfa72817f1b5aab94658238ddcdc08010,
+      x"fa72817f1b5aab94658238ddcdc08010",
+      // random consensus_pubkey: vector<u8>,
+      x"8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010", 
+      b"192.168.0.1", // validator_network_addresses: vector<u8>,
+      b"192.168.0.1", // fullnode_network_addresses: vector<u8>,
+      x"1ee7", // human_name: vector<u8>,
+  );
 
-//   // the prospective validator is in the current miner list.
-//   // assert(Vector::contains<address>(&TowerState::get_miner_list(), &eve_addr), 7357401002);
-// }
-// }
-// // check: EXECUTED
+  // the prospective validator is in the current miner list.
+  // assert(Vector::contains<address>(&TowerState::get_miner_list(), &eve_addr), 7357401002);
+}
+}
+// check: EXECUTED
 
 
 

--- a/ol/integration-tests/test-onboard-user.mk
+++ b/ol/integration-tests/test-onboard-user.mk
@@ -1,0 +1,160 @@
+SHELL=/usr/bin/env bash
+DATA_PATH = ${HOME}/.0L
+SWARM_TEMP = ${DATA_PATH}/swarm_temp
+LOG=${DATA_PATH}/test-onboard.log
+UNAME := $(shell uname)
+
+NODE_ENV=test
+TEST=y
+
+ifndef SOURCE_PATH
+SOURCE_PATH = ${HOME}/libra
+endif
+MAKE_FILE = ${SOURCE_PATH}/ol/integration-tests/test-onboard.mk
+
+# alice
+ifndef PERSONA
+PERSONA=alice
+endif
+
+# Eve mnemonic
+MNEM="recall october regret kite undo choice outside season business wall quit arrest vacant arrow giggle vote ghost winter hawk soft cheap decide exhaust spare"
+
+NUM_NODES = 2
+EVE = 3DC18D1CF61FAAC6AC70E3A63F062E4B
+
+# ONBOARD_FILE=${SOURCE_PATH}/ol/fixtures/account/swarm/eve.fixed_recurring.account.json
+
+ONBOARD_FILE= ${DATA_PATH}/account.json
+
+START_TEXT = "To run the Diem CLI client"
+SUCCESS_TEXT = "User transactions successfully relayed"
+
+export
+
+# account.json fixtures generated with:
+# cargo r -p onboard -- --swarm-path ./whatever val --upstream-peer http://167.172.248.37/
+
+test: swarm check-swarm send-tx check-tx check-account-created stop
+# Testing the Onboarding of Eve, there are many steps, and it involved Eve (to be onboarded), Alice (the onboarder), and Bob, a community wallet Eve wants to donate to.
+
+# 1. swarm - start swarm with 2 nodes, Alice and Bob
+# 2. check-swarm - check swarm is running
+# 3. set-community - set Bob's account as a community wallet
+# 4. create-json - create all onboarding files for Eve 
+# 5. send-tx - send the onboarding transaction from Alice's account to create Eve
+# 6. check-tx - check that the onboarding tx works and was accepted.
+# 7. check-account-created - checks that Eve's account was created.
+# 8. check-autopay - checks that the autopay instruction on chain includes Bob's address
+# 9. TODO: check-transfer - check repeatedly (over epochs) if Bob's account is receiving autopay payments from Eve. NOTE: Since the onboarding transfer is on 1 gas and tx fees push the balance below 1, autopay is disabled to prevent the account doesn't get locked.
+
+# That's a successful onboarding.
+
+swarm:
+	@echo Building Swarm
+	rm -rf ${SWARM_TEMP}
+	mkdir ${SWARM_TEMP}
+	cd ${SOURCE_PATH} && cargo build -p diem-node -p cli
+	cd ${SOURCE_PATH} && NODE_ENV=test TEST=y cargo run -p diem-swarm -- --diem-node ${SOURCE_PATH}/target/debug/diem-node -c ${SWARM_TEMP} -n ${NUM_NODES} &> ${LOG} &
+
+stop:
+	killall diem-swarm diem-node tower ol txs cli | true
+
+init:
+	@echo INIT
+	cd ${SOURCE_PATH} && cargo r -p ol -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} init --source-path ${SOURCE_PATH}
+
+create-json:
+	cp ${SOURCE_PATH}/ol/fixtures/autopay/alice.autopay_batch.json ${DATA_PATH}/autopay_batch.json
+
+# This account Eve account.json needs to be created on the fly, because there is a tx expiry param, which has a max of approx 7 days, which means CI tests will fail with state fixtures.
+
+# note we need the swarm-path so that the onboarding takes the tx params for swarm, otherwise the tx will fail
+# we pass all these params so that the wizard does not dialogue with us.
+
+# TODO: Makefile question: Why do we need to set MNEM set to itself here?
+	MNEM=${MNEM} cargo r -p onboard -- --swarm-path ~/swarm_temp val --upstream-peer http://localhost --epoch 5 --waypoint '0:683185844ef67e5c8eeaa158e635de2a4c574ce7bbb7f41f787d38db2d623ae2' --home-path ${DATA_PATH} --output-path ${DATA_PATH} --ci
+
+
+ 
+tx: balance-alice
+	@echo SENDING ONBOARDING TX
+	cd ${SOURCE_PATH} && NODE_ENV=test TEST=y cargo r -p txs -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} create-account -a 2bffcbd0e9016013cb8ca78459f69d2b3dc18d1cf61faac6ac70e3a63f062e4b -c 1
+
+set-community:
+	cd ${SOURCE_PATH} && NODE_ENV=test TEST=y cargo r -p txs -- --swarm-path ${SWARM_TEMP} --swarm-persona bob wallet -c
+
+resources:
+	cd ${SOURCE_PATH} && cargo run -p ol -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} --account ${EVE} query --resources
+
+balance:
+	cd ${SOURCE_PATH} && cargo run -p ol -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} --account 3DC18D1CF61FAAC6AC70E3A63F062E4B query --balance
+
+query-autopay:
+	cd ${SOURCE_PATH} && cargo run -p ol -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} --account 3DC18D1CF61FAAC6AC70E3A63F062E4B query --move-state --move-module AutoPay --move-struct Data --move-value payments
+
+balance-alice:
+	cd ${SOURCE_PATH} && cargo run -p ol -- --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} --account 4C613C2F4B1E67CA8D98A542EE3F59F5 query --balance
+
+balance-bob:
+	cd ${SOURCE_PATH} && cargo run -p ol -- --account 88E74DFED34420F2AD8032148280A84B --swarm-path ${SWARM_TEMP} --swarm-persona ${PERSONA} query --balance
+
+
+check-swarm: 
+	@while [[ ${NOW} -le ${END} ]] ; do \
+			if grep -q ${START_TEXT} ${LOG} ; then \
+				break; \
+			else \
+				echo . ; \
+			fi ; \
+			echo "Sleeping for 5 secs" ; \
+			sleep 5 ; \
+	done
+
+send-tx: 
+	PERSONA=alice make -f ${MAKE_FILE} init
+	PERSONA=alice make -f ${MAKE_FILE} tx &>> ${LOG} &
+
+check-tx:
+	@while [[ ${NOW} -le ${END} ]] ; do \
+			if grep -q ${SUCCESS_TEXT} ${LOG} ; then \
+				echo TX SUCCESS ; \
+				break ; \
+			else \
+				echo . ; \
+			fi ; \
+			echo "Sleeping for 5 secs" ; \
+			sleep 5 ; \
+	done
+
+check-account-created: 
+# checks if there is any mention of BOB's account as a payee on EVE's account
+	PERSONA=alice make -f ${MAKE_FILE} resources | grep -e 'payee'
+
+	
+check-autopay:
+# swarm accounts start with a balance of 10, check that the balance increases
+	@while [[ ${NOW} -le ${END} ]] ; do \
+			if PERSONA=alice make -f ${MAKE_FILE} query-autopay | grep -e '88E74DFED34420F2AD8032148280A84B'; then \
+				echo TX SUCCESS ; \
+				break ; \
+			else \
+				echo . ; \
+			fi ; \
+			echo "Sleeping for 5 secs" ; \
+			sleep 5 ; \
+	done
+	
+
+# check-transfer:
+# # swarm accounts start with a balance of 10, check that the balance increases
+# 	@while [[ ${NOW} -le ${END} ]] ; do \
+# 			if PERSONA=alice make -f ${MAKE_FILE} balance-bob | grep -e '10' -e '11' -e '15'; then \
+# 				echo TX SUCCESS ; \
+# 				break ; \
+# 			else \
+# 				echo . ; \
+# 			fi ; \
+# 			echo "Sleeping for 5 secs" ; \
+# 			sleep 5 ; \
+# 	done


### PR DESCRIPTION
Users who had accounts created (but never mined), and later expected to upgrade those accounts to validators, could not. The account creation was checking if TowerState was created. And this prevent users in that case from being upgraded.

- [x] Modify DiemAccount upgrade_validator_account_with_proof
- [x] Move test for the upgrade case
- [x] Move test for creating end user account by sending a coin.