### PR TITLE
Patch bug on rate limit of validator account creation

### DIFF
--- a/language/diem-framework/modules/0L/TowerState.move
+++ b/language/diem-framework/modules/0L/TowerState.move
@@ -21,7 +21,7 @@ module TowerState {
     use 0x1::VDF;
     use 0x1::Vector;
 
-    const EPOCHS_UNTIL_ACCOUNT_CREATION: u64 = 6;
+    const EPOCHS_UNTIL_ACCOUNT_CREATION: u64 = 13;
 
     /// A list of all miners' addresses 
     // reset at epoch boundary


### PR DESCRIPTION
Reversion in code from a merge error. The parameters set for rate-limit of validator account creation was set to 13 epochs when slated for mainnet. Previously on the experimental network it was hard-coded to 6.  This patch corrects it. This is a one line change.