### PR TITLE
TowerState check difficulty on initialize

### DIFF
--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -125,7 +125,7 @@ impl StorageHelper {
             // Data needed for testnet, swarm, and genesis ceremony.
             let mut storage_root = self.storage("root".to_owned());
             let dummy_root = Ed25519PrivateKey::from_encoded_string(
-                "8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010"
+                "8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010" // protests rage accross the nation
             ).unwrap();
 
             storage_root

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{fs::File, io::Read, path::PathBuf};
+
 use diem_config::config::RocksdbConfig;
 use diem_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use diem_temppath::TempPath;
@@ -25,7 +27,7 @@ pub struct CreateWaypoint {
     #[structopt(long)]
     genesis_path: Option<std::path::PathBuf>,
     #[structopt(long)]
-    layout_path: Option<std::path::PathBuf>,   
+    layout_path: Option<std::path::PathBuf>,
 }
 
 impl CreateWaypoint {
@@ -33,8 +35,8 @@ impl CreateWaypoint {
         let genesis_helper = crate::genesis::Genesis {
             config: self.config,
             chain_id: self.chain_id,
-            backend: self.shared_backend,            
-            path: self.genesis_path, //////// 0L ////////
+            backend: self.shared_backend,
+            path: self.genesis_path,       //////// 0L ////////
             layout_path: self.layout_path, //////// 0L ////////
         };
 
@@ -48,15 +50,37 @@ impl CreateWaypoint {
         db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &genesis)
             .map_err(|e| Error::UnexpectedError(e.to_string()))
     }
+}
 
-    //////// 0L ////////
-    pub fn extract_waypoint(gen_tx: Transaction) -> Result<Waypoint, Error> {
-      let path = TempPath::new();
-      let libradb =
-          DiemDB::open(&path, false, None, RocksdbConfig::default()).map_err(|e| Error::UnexpectedError(e.to_string()))?;
-      let db_rw = DbReaderWriter::new(libradb);
+//////// 0L ////////
 
-      db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &gen_tx)
-          .map_err(|e| Error::UnexpectedError(e.to_string()))
-    }
+pub fn extract_waypoint_from_file(genesis_path: &PathBuf) -> Result<Waypoint, Error> {
+    let mut file = File::open(genesis_path)
+        .map_err(|_| Error::UnexpectedError("cannot open genesis.blob file".to_string()))?;
+
+    let mut buffer = vec![];
+    file.read_to_end(&mut buffer)
+        .map_err(|_| Error::UnexpectedError("cannot open genesis.blob file".to_string()))?;
+
+    let gen_tx: Transaction = bcs::from_bytes(&buffer)
+        .map_err(|_| Error::UnexpectedError("cannot open genesis.blob file".to_string()))?;
+
+    let path = TempPath::new();
+    let libradb = DiemDB::open(&path, false, None, RocksdbConfig::default())
+        .map_err(|e| Error::UnexpectedError(e.to_string()))?;
+    let db_rw = DbReaderWriter::new(libradb);
+
+    db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &gen_tx)
+        .map_err(|e| Error::UnexpectedError(e.to_string()))
+}
+
+//////// 0L ////////
+pub fn extract_waypoint(gen_tx: Transaction) -> Result<Waypoint, Error> {
+    let path = TempPath::new();
+    let libradb = DiemDB::open(&path, false, None, RocksdbConfig::default())
+        .map_err(|e| Error::UnexpectedError(e.to_string()))?;
+    let db_rw = DbReaderWriter::new(libradb);
+
+    db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &gen_tx)
+        .map_err(|e| Error::UnexpectedError(e.to_string()))
 }

--- a/language/diem-framework/modules/0L/TowerState.move
+++ b/language/diem-framework/modules/0L/TowerState.move
@@ -197,6 +197,13 @@ module TowerState {
     ) acquires TowerProofHistory, TowerList, TowerStats {
       // Get address, assumes the sender is the signer.
       let miner_addr = Signer::address_of(miner_sign);
+      
+      // Skip this check on local tests, we need tests to send different difficulties.
+      if (!Testnet::is_testnet()){
+        // Get vdf difficulty constant. Will be different in tests than in production.
+        let difficulty_constant = Globals::get_vdf_difficulty();
+        assert(&proof.difficulty == &difficulty_constant, Errors::invalid_argument(130102));
+      };
 
       // This may be the 0th proof of an end user that hasn't had tower state initialized
       if (!is_init(miner_addr)) {
@@ -208,12 +215,7 @@ module TowerState {
         return
       };
 
-      // Skip this check on local tests, we need tests to send different difficulties.
-      if (!Testnet::is_testnet()){
-        // Get vdf difficulty constant. Will be different in tests than in production.
-        let difficulty_constant = Globals::get_vdf_difficulty();
-        assert(&proof.difficulty == &difficulty_constant, Errors::invalid_argument(130102));
-      };
+
       // Process the proof
       verify_and_update_state(miner_addr, proof, true);
     }

--- a/ol/documentation/node-ops/validators/validator_onboarding_easy_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_easy_mode.md
@@ -65,9 +65,12 @@ Your `tower` app will produce a proof which is needed to create an account. This
 The `start` subcommand will run `pilot` app which continuously checks node and tower state and changes nodes. 
 
 ```
+# Restore from the latest epoch snapshot instead of syncing the entire chain
+> ol restore
+
 # start all 0L services and restore chain from archive
 
-> ol start --restore
+> ol start
 
 # press <ctrl+b> then <d> to detach from tmux without stopping the app. Reattach with `tmux a`
 ```

--- a/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
@@ -32,10 +32,17 @@ You need to open ports 6179, 6180, 8080, 3030 on the host
 These instructions target Ubuntu.
 
 1.1. Set up an Ubuntu host with `ssh` access, e.g. in a cloud service provider. 
-1.2.  Associate a static IP  with your host, this will be tied to you account, and will be set in your `account.json` file.
-1.3. You'll want to use `tmux` to persist the terminal session for build, as well as for running the nodes and tower app. 
 
-tmux
+1.2.  Associate a static IP  with your host, this will be tied to you account, and will be set in your `account.json` file.
+
+1.3. You'll want to use `tmux` to persist the terminal session for build, as well as for running the nodes and tower app. Also this setup requires `git` and `make`, which might be installed already on your host. If not, perform the following steps now:
+
+```
+sudo apt install tmux git make
+```
+
+It is recommended to perform the steps from 1.4 onwards inside tmux. Short tmux intruction:
+
 ```
 # start a new tmux session
 tmux new -s build
@@ -45,23 +52,23 @@ tmux attach -t build
 ```
 to detach from the `tmux` session `Ctrl-b d`
 
-1.3. Clone this repo: 
+1.4. Clone this repo: 
 
 `git clone https://github.com/OLSF/libra.git`
 
-1.4. Config dependencies: 
+1.5. Config dependencies: 
 
 using make or running the `ol/utils/setup.sh` script directly
 
 using make
 ```
-sudo apt install make
+cd </path/to/libra-source/>
 make deps
 ```
 
 or run the script directly
 ```
-cd </path/to/libra/source/> && . ol/util/setup.sh
+cd </path/to/libra-source/> && . ol/util/setup.sh
 ```
 
 After `rust` and `cargo` are installed you are prompted to set a `PATH` environment variable. 
@@ -74,18 +81,15 @@ To configure your current shell, run:
 source $HOME/.cargo/env
 ```
 
-or reset your terminal
-```
-reset
-```
 
 For more details: (../devs/OS_dependencies.md)
 
-1.5. Build the source and install binaries:
-This takes a while, run inside `tmux` in case your session gets disconnected 
+1.6. Build the source and install binaries:
+This takes a while, run inside `tmux` to avoid your session gets disconnected 
 ```
-cd </path/to/libra/source/> 
+cd </path/to/libra-source/> 
 make bins && make install
+source $HOME/.bashrc
 ```
 
 ## 2. Generate an account
@@ -102,13 +106,13 @@ to place in your first proof.
 
 ```
 # start wizard
-onboard val -u http://<ip-address>:3030
+onboard val -u http://<ip-address-of-the-one-who-onboards-you>:3030
 
 # without template, note: assumes an autopay_batch.json is in the project root.
 onboard val
 ```
 
-2.3. Send the generated `~/.0L/account.json` to someone that has GAS and can execute the account creation transaction for you.
+2.3. Send the generated `~/.0L/account.json` to someone that has GAS (the one who wants to onboard you) and can execute the account creation transaction for you.
 
 **If you are onboaring someone and receive the `account.json` [see](#onboarder-instructions)**  
 
@@ -242,7 +246,7 @@ ol explorer
 If you are onboarding someone and have received their `account.json` file
 1. Copy the `account.json` to your local node.
 2. Submit a tx with `txs` app:
-   `txs create-validator <path/to/account.json>
+   `txs create-validator --account-file <path/to/account.json>
 
 Troubleshooting: If there is an issue with sequence_number out of sync. Retry the transaction.
 

--- a/ol/onboard/src/commands/files_cmd.rs
+++ b/ol/onboard/src/commands/files_cmd.rs
@@ -60,8 +60,8 @@ pub fn genesis_files(
     ol_node_files::write_node_config_files(
         home_dir.clone(),
         chain_id.unwrap_or(1),
-        &github_org.clone().unwrap_or("OLSF".to_string()),
-        &repo.clone().unwrap_or("experimetal-genesis".to_string()),
+        github_org.clone(),
+        repo.clone(),
         &namespace,
         prebuilt_genesis,
         fullnode_only,

--- a/ol/onboard/src/commands/wizard_fn_cmd.rs
+++ b/ol/onboard/src/commands/wizard_fn_cmd.rs
@@ -23,8 +23,8 @@ pub struct FnWizardCmd {
     prebuilt_genesis: Option<PathBuf>,
     #[options(help = "skip fetching genesis blob")]
     skip_fetch_genesis: bool,
-    #[options(help = "optional waypoint")]
-    waypoint: Option<Waypoint>,
+    // #[options(help = "optional waypoint")]
+    // waypoint: Option<Waypoint>,
 }
 
 impl Runnable for FnWizardCmd {
@@ -57,15 +57,12 @@ impl Runnable for FnWizardCmd {
         ol_node_files::write_node_config_files(
             home_dir.clone(),
             self.chain_id.unwrap_or(1),
-            &self.github_org.clone().unwrap_or("OLSF".to_string()),
-            &self
-                .repo
-                .clone()
-                .unwrap_or("experimental-genesis".to_string()),
+            self.github_org.clone(),
+            self.repo.clone(),
             &namespace,
             &self.prebuilt_genesis,
             &true,
-            self.waypoint,
+            None,
             &None,
         ).unwrap();
         status_ok!("\nNode config OK", "\n...........................\n");

--- a/ol/onboard/src/commands/wizard_fork_cmd.rs
+++ b/ol/onboard/src/commands/wizard_fork_cmd.rs
@@ -6,7 +6,6 @@ use super::files_cmd;
 
 use crate::entrypoint;
 use crate::prelude::app_config;
-use crate::read_genesis::gen_tx_from_blob;
 use abscissa_core::{status_info, status_ok, Command, Options, Runnable};
 use diem_genesis_tool::{ol_node_files, waypoint};
 use diem_types::transaction::SignedTransaction;
@@ -84,8 +83,7 @@ impl Runnable for ForkCmd {
 
         let mut wp = self.waypoint.clone();
         if let Some(path) = &self.prebuilt_genesis {
-          let tx = gen_tx_from_blob(path).unwrap();
-          wp = Some(waypoint::CreateWaypoint::extract_waypoint(tx).unwrap());
+          wp = Some(waypoint::extract_waypoint_from_file(path).unwrap());
           dbg!(&wp);
         }
 
@@ -155,11 +153,8 @@ impl Runnable for ForkCmd {
         ol_node_files::write_node_config_files(
             home_dir.clone(),
             self.chain_id.unwrap_or(1),
-            &self.github_org.clone().unwrap_or("OLSF".to_string()),
-            &self
-                .repo
-                .clone()
-                .unwrap_or("experimental-genesis".to_string()),
+            self.github_org.clone(),
+            self.repo.clone(),
             &namespace,
             &prebuilt_genesis_path,
             &false,

--- a/ol/onboard/src/commands/wizard_val_cmd.rs
+++ b/ol/onboard/src/commands/wizard_val_cmd.rs
@@ -133,6 +133,7 @@ impl Runnable for ValWizardCmd {
         );
 
         // Initialize Validator Keys
+        // this also sets a genesis waypoint if one was provide, e.g. from an upstream peer.
         init_cmd::initialize_validator(&wallet, &app_config, base_waypoint, *&self.genesis_ceremony).expect("could not initialize validator key_store.json");
         status_ok!("\nKey file written", "\n...........................\n");
 
@@ -316,17 +317,15 @@ fn get_genesis_and_make_node_files(cmd: &ValWizardCmd, home_path: &PathBuf, base
 
   let home_dir = app_config.workspace.node_home.to_owned();
   // 0L convention is for the namespace of the operator to be appended by '-oper'
-  let namespace = app_config.profile.auth_key.clone().to_string() + "-oper";
+  // this needs to be the same namespace as in initialize_validator
+  let namespace = app_config.profile.account.to_hex() + "-oper";
 
   // TODO: use node_config to get the seed peers and then write upstream_node vec in 0L.toml from that.
   ol_node_files::write_node_config_files(
       home_dir.clone(),
       cmd.chain_id.unwrap_or(1),
-      &cmd.github_org.clone().unwrap_or("OLSF".to_string()),
-      &cmd
-          .repo
-          .clone()
-          .unwrap_or("genesis-registration".to_string()),
+      cmd.github_org.clone(),
+      cmd.repo.clone(),
       &namespace,
       &genesis_blob_path,
       &false,

--- a/ol/types/src/config.rs
+++ b/ol/types/src/config.rs
@@ -566,7 +566,7 @@ pub fn bootstrap_waypoint_from_upstream(url: &mut Url) -> Result<(u64, Waypoint)
 struct WaypointRpc {
     result: Option<serde_json::Value>,
 }
-// get the waypoint from a fullnode
+/// get the waypoint from a fullnode
 pub fn bootstrap_waypoint_from_rpc(url: Url) -> Result<Waypoint, Error> {
     let method = "get_waypoint_view";
     let params = json!([]);


### PR DESCRIPTION
With the new workflow of end-users being able to register without doing a vdf proof, and also being able to initialize TowerState on the submission of the first proof, there's a bug where the checking of the difficulty was being skipped because of an early return. This code changes the order such that difficulty is checked first on commit_state().