### PR TITLE
TowerState check difficulty on initialize

### DIFF
--- a/language/diem-framework/modules/0L/TowerState.move
+++ b/language/diem-framework/modules/0L/TowerState.move
@@ -197,6 +197,13 @@ module TowerState {
     ) acquires TowerProofHistory, TowerList, TowerStats {
       // Get address, assumes the sender is the signer.
       let miner_addr = Signer::address_of(miner_sign);
+      
+      // Skip this check on local tests, we need tests to send different difficulties.
+      if (!Testnet::is_testnet()){
+        // Get vdf difficulty constant. Will be different in tests than in production.
+        let difficulty_constant = Globals::get_vdf_difficulty();
+        assert(&proof.difficulty == &difficulty_constant, Errors::invalid_argument(130102));
+      };
 
       // This may be the 0th proof of an end user that hasn't had tower state initialized
       if (!is_init(miner_addr)) {
@@ -208,12 +215,7 @@ module TowerState {
         return
       };
 
-      // Skip this check on local tests, we need tests to send different difficulties.
-      if (!Testnet::is_testnet()){
-        // Get vdf difficulty constant. Will be different in tests than in production.
-        let difficulty_constant = Globals::get_vdf_difficulty();
-        assert(&proof.difficulty == &difficulty_constant, Errors::invalid_argument(130102));
-      };
+
       // Process the proof
       verify_and_update_state(miner_addr, proof, true);
     }


### PR DESCRIPTION
With the new workflow of end-users being able to register without doing a vdf proof, and also being able to initialize TowerState on the submission of the first proof, there's a bug where the checking of the difficulty was being skipped because of an early return. This code changes the order such that difficulty is checked first on commit_state().

