### PR TITLE
added missing doc how to set up web monitor

### DIFF
--- a/ol/documentation/node-ops/start_a_full_node.md
+++ b/ol/documentation/node-ops/start_a_full_node.md
@@ -22,8 +22,6 @@ cd </path/to/libra/source/>
 . ol/util/setup.sh
 ```
 
-More details in: [syncing_your_node.md](syncing_your_node.md)
-
 1.5. Build the source and install binaries:
 
 ```
@@ -38,6 +36,14 @@ You do not need an account for this step, you are simply syncing the database.
 
 2.1. Restore from most recent backup in epoch-archive: `ol restore`
 
-2.2. `diem-node --config $HOME/.0L/fullnode.node.yaml`
+2.2. Run the node (remember to do it in a `screen` or `tmux` session): `diem-node --config $HOME/.0L/fullnode.node.yaml`
+
 
 More details in: [syncing_your_node.md](syncing_your_node.md)
+
+## 3. Set up web monitor
+
+Optionally you can set up the web monitor to have easy access to server status via your web browser:
+
+[Set up web monitor](validators/web_monitor.md) 
+

--- a/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
@@ -185,6 +185,10 @@ You might see some network errors due to drops, but should again see round numbe
 
 This command will tell you the sync state of a RUNNING local node: `db-backup one-shot query node-state`
 
+While waiting for the sync to complete, it is a good opportunity, to set up the web monitor (but you can also do it any time later). Please follow the instructions here:
+
+[Set up web monitor](web_monitor.md) 
+
 ## 5. Start producing delay proofs ("delay mining") 
 
 Before you start: You will need your mnemonic.

--- a/ol/documentation/node-ops/validators/web_monitor.md
+++ b/ol/documentation/node-ops/validators/web_monitor.md
@@ -1,0 +1,38 @@
+# How to Configure Web Monitor
+
+## Why
+When you operate a full node or validator node you might be interested in a monitoring tool which shows the current node status accessible by your web browser.
+
+## How to set up
+
+After your node is set up and you already have a $HOME/.0L directory, you have to install the static web files there:
+
+```
+cd $HOME/libra  # the directory where you checked out the source
+make web-files
+```
+
+You might verify that a new directory has been created $HOME/.0L/web-monitor
+
+## How to start it
+
+It is strongly recommended to let the web-monitor run in a tmux session, as also done for the diem-node and tower app:
+
+```
+tmux new -t monitor
+```
+
+Start the web monitor in this tmux session by the following command:
+
+```
+ol serve -c
+```
+
+## How to access it
+
+Once the web monitor is running, you can access it in your browser at the following URL:
+
+```
+http://<your-ip-address>:3030
+```
+


### PR DESCRIPTION
## Motivation

We missed to document how to set up the web monitor

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Check the updated doc files
- validators/web_monitor.md
- references to this doc in start_a_full_node.md and validator_onboarding_hard_mode.md

