### PR TITLE
Fix web-monitor filename in update_web

### DIFF
--- a/ol/cli/src/server.rs
+++ b/ol/cli/src/server.rs
@@ -98,7 +98,7 @@ fn sse_vitals(data: Vitals) -> Result<Event, Error> {
 
 /// Fetch updated static web files from release, for web-monitor.
 pub fn update_web(home_path: &PathBuf) {
-    let file_name = "web-monitor.zip";
+    let file_name = "web-monitor.tar.gz";
     let url = &format!(
         "https://github.com/OLSF/libra/releases/latest/download/{}",
         file_name


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The filename for web-monitor didn't match your release artifacts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No changes

## Related PRs

## If targeting a release branch, please fill the below out as well

