### PR TITLE
Correct command in validator hard mode guide

### DIFF
--- a/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
@@ -243,9 +243,9 @@ diem-node --config  ~/.0L/validator.node.yaml >> ~/.0L/logs/validator.log 2>&1
 
 6.2 Restart the tower app after your validator is running, refer to [Step 5](#5-start-producing-delay-proofs-delay-mining) - ctrl+ C and restart it. 
 
-Once you have been on boarded you should see you public key in the list of validators. Run the explorer to view:
+Once you have been on boarded you should see you public key in the list of validators. Run the web monitor to view:
 ```
-ol explorer
+ol serve -c
 ```
 ---
 


### PR DESCRIPTION
## Motivation

Explorer run command was wrong (it was using an old command), and has been fixed from explorer to serve.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yeah

## Test Plan

N/A

## Related PRs

N/A