### PR TITLE
Dynamically set the user home directory in systemd unit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,10 +315,8 @@ start-full:
 	cargo run -p diem-node -- --config ${DATA_PATH}/fullnode.node.yaml
 
 daemon:
-# your node's custom diem-node.service lives in ~/.0L. Take the template from libra/util and edit for your needs.
-	@echo REMEMBER TO COPY A TEMPLATE from ./ol/util/diem-node.service and edit the username
 	mkdir -p ~/.config/systemd/user/
-	cp ~/.0L/diem-node.service ~/.config/systemd/user/
+	cp ./ol/util/diem-node.service ~/.config/systemd/user/
 
 	@if test -d ~/logs; then \
 		echo "WIPING SYSTEMD LOGS"; \

--- a/ol/documentation/node-ops/validators/validator_daemon_configs.md
+++ b/ol/documentation/node-ops/validators/validator_daemon_configs.md
@@ -19,9 +19,9 @@ There are a few file paths you will be working from:
 
 This will use a `make` recipe to start the node daemon and install the daemon configs.
 
-First. Copy a template for systemd from `<project root>/util/diem-node.system` into your 0L home path, usually `~/.0L`. This is non-root template file needs to be edited: replace occurrences of `<<YOUR USERNAME!>>` with the username under which the service will run.
+A template `ol/util/diem-node.service` will be copied into your `~/.config/systemd/user/` path to setup the service. This is non-root template file which uses the home directory of the managing user of the service.
 
-BEFORE PROCEEDING: Check you have `~/.0L/diem-node.system` in place and edited with your usename.
+BEFORE PROCEEDING: Check that you have `ol/util/diem-node.service` in place.
 
 Now the Makefile can do a number of things including coping that file to the usual place, and then (re)starting the service.
 
@@ -29,7 +29,7 @@ From the project root:
 
 `make daemon`
 
-# Slow Start
+# Configure manually
 
 ## Build binaries and copy to appropriate path
 Use `make bins install` or alternatively:
@@ -39,7 +39,7 @@ Use `make bins install` or alternatively:
 In `~/.config/systemd/user/` you should create a file like this. (Note: again, `make daemon` does this for you)
 
 ```
-# edit this document and replace <<YOUR USERNAME!>> with your linux user
+# this assumes that the managing user of the service is `node`, hence the `/home/node` home path prefix
 [Unit]
 Description=0L Node Service
 

--- a/ol/util/diem-node.service
+++ b/ol/util/diem-node.service
@@ -1,20 +1,18 @@
-# edit this document and replace <<YOUR USERNAME!>> with your linux user
 [Unit]
 Description=0L Node Service
 
 [Service]
 LimitNOFILE=200000
 
-WorkingDirectory=/home/<<YOUR USERNAME!>>/.0L
-ExecStart=/home/<<YOUR USERNAME!>>/bin/diem-node --config /home/<<YOUR USERNAME!>>/.0L/validator.node.yaml
-
+WorkingDirectory=%h/.0L
+ExecStart=%h/bin/diem-node --config %h/.0L/validator.node.yaml
 
 Restart=always
 RestartSec=10s
 
 # Make sure you CREATE the directory and file for your node.log
-StandardOutput=file:/home/<<YOUR USERNAME!>>/logs/node.log
-StandardError=file:/home/<<YOUR USERNAME!>>/logs/node.log
+StandardOutput=file:%h/.0L/logs/node.log
+StandardError=file:%h/.0L/logs/node.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Motivation

Currently users need to update a template manually and start systemd. Goal is to make systemd setup automated.

Related issue: https://github.com/OLSF/libra/issues/543

## Test Plan

I am not familiar with testing systemd or if automated testing is possible, but this was tested on Ubuntu 20.04 (LTS) x64 manually, and it works.

