### PR TITLE
Prevent panics in stdlib upgrade

### DIFF
--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -519,13 +519,13 @@ impl DiemVMImpl {
                     let mut bytes = vec![];
                     module
                         .serialize(&mut bytes)
-                        .expect("Failed to serialize module");
+                        .map_err(|e| { info!("Failed to serialize module: {}", e); VMStatus::Error(StatusCode::STDLIB_UPGRADE_ERROR) })?;
                     session.revise_module(
                         bytes, 
                         account_config::CORE_CODE_ADDRESS, 
                         gas_status, 
                         log_context
-                    ).expect("Failed to publish module");
+                    ).map_err(|e| { info!("Failed to publish module: {}", e); VMStatus::Error(StatusCode::STDLIB_UPGRADE_ERROR) })?;
                     counter += 1;
                 }
                 info!("0L ==== stdlib upgrade: published {} modules", counter);
@@ -542,7 +542,7 @@ impl DiemVMImpl {
                     // txn_data.sender(),
                     gas_status,
                     log_context,
-                ).expect("Couldn't reset payload");
+                ).map_err(|e| { info!("Couldn't reset payload: {}", e); VMStatus::Error(StatusCode::STDLIB_UPGRADE_ERROR) })?;
                 info!("==== stdlib upgrade: end upgrade at time: {} ====", timestamp);
             }
         }

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -513,7 +513,8 @@ impl DiemVMImpl {
                 info!("0L ==== stdlib upgrade: upgrade payload elected in previous epoch");
 
                 // publish the agreed stdlib
-                let new_stdlib = import_stdlib(&payload);
+                let new_stdlib = import_stdlib(&payload)
+                    .map_err(|e| { info!("Failed to import stdlib: {}", e); VMStatus::Error(StatusCode::STDLIB_UPGRADE_ERROR) })?;
                 let mut counter = 0;
                 for module in new_stdlib {
                     let mut bytes = vec![];

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -635,6 +635,7 @@ pub enum StatusCode {
     CALL_STACK_OVERFLOW = 4021,
     VM_MAX_TYPE_DEPTH_REACHED = 4024,
     VM_MAX_VALUE_DEPTH_REACHED = 4025,
+    STDLIB_UPGRADE_ERROR = 4026,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in


### PR DESCRIPTION
## Motivation
This issue: https://github.com/OLSF/libra/issues/901.
To summarize: Malformed bytes can cause a panic while attempting to upgrade the standard library, causing a network fault.
To fix this, we log any errors and return an error status code instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

## Testing

I ran cargo test in the two crates I modified (all tests pass).
And ran an integration test using 
`make -f ol/integration-tests/test-upgrade.mk test`. 
