### PR TITLE
[mempool] Ensure mempool resends all txns after disconnect

### DIFF
--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -565,8 +565,8 @@ fn test_interruption_in_sync() {
     // B reconnects to A
     harness.connect(&v_b, &v_a);
 
-    // B should receive the remaining txns
-    for seq_num in 1..3 {
+    // B should receive all txns
+    for seq_num in 0..3 {
         harness.broadcast_txns_and_validate(v_a, v_b, seq_num);
     }
 }


### PR DESCRIPTION
Validators don't resend txns after disconnect to ones that have already
confirmed which could cause some issues when many nodes restart or get
stuck.