### PR TITLE
Raise the log level for peer disconnection from

### DIFF
--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -383,7 +383,7 @@ impl HealthChecker {
                         // ConnectivityManager or the remote peer to re-establish the connection.
                         *failures += 1;
                         if *failures > self.ping_failures_tolerated {
-                            info!(
+                            error!(
                                 NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
                                 "{} Disconnecting from peer: {}",
                                 self.network_context,


### PR DESCRIPTION
Raise the log level of peer disconnection events to error. I think this will help diagnose network halts.