### PR TITLE
Tower 72 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8555,6 +8555,7 @@ dependencies = [
  "classgroup",
  "cli",
  "criterion",
+ "diem-client",
  "diem-config",
  "diem-crypto",
  "diem-genesis-tool",

--- a/ol/tower/Cargo.toml
+++ b/ol/tower/Cargo.toml
@@ -39,6 +39,7 @@ toml = "0.5.6"
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 diem-global-constants = { path = "../../config/global-constants"}
 dirs = "2.0.2"
+diem-client = { path = "../../sdk/client" }
 diem-genesis-tool = { path = "../../config/management/genesis" }
 diem-management = { path = "../../config/management" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }

--- a/ol/tower/src/backlog.rs
+++ b/ol/tower/src/backlog.rs
@@ -62,7 +62,7 @@ pub fn process_backlog(
                 match eval_tx_status(view) {
                     Ok(_) => {}
                     Err(e) => {
-                        warn!("WARN: could not fetch TX status, continuing to next block in backlog after 30 seconds. Message: {:?} ", e);
+                        warn!("WARN: could not fetch TX status. Message: {:?} ", e);
                         break;
                     }
                 };

--- a/ol/tower/src/backlog.rs
+++ b/ol/tower/src/backlog.rs
@@ -53,7 +53,7 @@ pub fn process_backlog(
             while i <= current_block_number.into() && j < remaining_proofs_in_epoch {
                 let path =
                     PathBuf::from(format!("{}/{}_{}.json", blocks_dir.display(), FILENAME, i));
-                info!("submitting proof {}", i);
+                info!("submitting proof {}, in this backlog: {}", i, j);
                 let file = File::open(&path)?;
                 let reader = BufReader::new(file);
                 let block: VDFProof = serde_json::from_reader(reader)?;

--- a/ol/tower/src/backlog.rs
+++ b/ol/tower/src/backlog.rs
@@ -5,11 +5,12 @@ use crate::commit_proof::commit_proof_tx;
 use crate::proof::{parse_block_height, FILENAME};
 use anyhow::{bail, Error, Result};
 use cli::diem_client::DiemClient;
+use diem_client::views::TowerStateResourceView;
 use diem_logger::prelude::*;
 use ol_types::block::VDFProof;
 use ol_types::config::AppCfg;
 use std::io::BufReader;
-use std::{fs::File, path::PathBuf};
+use std::{cmp::max, fs::File, path::PathBuf};
 use txs::epoch::get_epoch;
 use txs::submit_tx::{eval_tx_status, TxParams};
 
@@ -45,7 +46,7 @@ pub fn process_backlog(
     let (current_block_number, _current_block_path) = parse_block_height(&blocks_dir);
     if let Some(current_block_number) = current_block_number {
         info!("Local tower height: {:?}", current_block_number);
-        if i128::from(current_block_number) > remote_height {
+        if i128::from(current_block_number) > remote_height as i128 {
             info!("Backlog: resubmitting missing proofs.");
 
             let mut i = remote_height + 1;

--- a/ol/tower/src/backlog.rs
+++ b/ol/tower/src/backlog.rs
@@ -1,26 +1,42 @@
 //! Miner resubmit backlog transactions module
 #![forbid(unsafe_code)]
 
-use cli::{diem_client::DiemClient};
-use ol_types::block::VDFProof;
-use txs::submit_tx::{TxParams, eval_tx_status};
-use std::{fs::File, path::PathBuf, thread, time};
-use ol_types::config::AppCfg;
 use crate::commit_proof::commit_proof_tx;
-use std::io::BufReader;
 use crate::proof::{parse_block_height, FILENAME};
-use anyhow::{bail, Result, Error};
+use anyhow::{bail, Error, Result};
+use cli::diem_client::DiemClient;
 use diem_logger::prelude::*;
+use ol_types::block::VDFProof;
+use ol_types::config::AppCfg;
+use std::io::BufReader;
+use std::{fs::File, path::PathBuf};
+use txs::epoch::get_epoch;
+use txs::submit_tx::{eval_tx_status, TxParams};
 
-/// Submit a backlog of blocks that may have been mined while network is offline. 
-/// Likely not more than 1. 
+// only 72 proofs are allowed per epoch
+const MAX_PROOFS_PER_EPOCH: i64 = 72;
+/// Submit a backlog of blocks that may have been mined while network is offline.
+/// Likely not more than 1.
 pub fn process_backlog(
-    config: &AppCfg, tx_params: &TxParams, is_operator: bool
+    config: &AppCfg,
+    tx_params: &TxParams,
+    is_operator: bool,
 ) -> Result<(), Error> {
     // Getting remote miner state
-    //let remote_state = get_remote_state(tx_params)?;
-    //let remote_height = remote_state.verified_tower_height;
-    let remote_height = get_remote_tower_height(tx_params).unwrap();
+    // Getting remote miner state
+    let remote_state = get_remote_state(tx_params)?;
+    let remote_height = remote_state.verified_tower_height;
+    let mut proofs_in_epoch: i64 = 0;
+    let current_epoch = get_epoch(tx_params);
+    if remote_state.latest_epoch_mining == current_epoch {
+        proofs_in_epoch = remote_state.count_proofs_in_epoch as i64;
+    }
+    let remaining_proofs_in_epoch: i64 = max(0, MAX_PROOFS_PER_EPOCH - proofs_in_epoch);
+    println!(
+        "Remote tower height: {}, proofs_in_epoch: {},
+        remaining_proofs_in_epoch: {}, current_epoch: {}",
+        remote_height, proofs_in_epoch, remaining_proofs_in_epoch, current_epoch
+    );
 
     info!("Remote tower height: {}", remote_height);
     // Getting local state height
@@ -33,53 +49,50 @@ pub fn process_backlog(
             info!("Backlog: resubmitting missing proofs.");
 
             let mut i = remote_height + 1;
-            while i <= current_block_number.into() {
-                let path = PathBuf::from(
-                    format!("{}/{}_{}.json", blocks_dir.display(), FILENAME, i)
-                );
+            let mut j = 0; // number of proofs submitted
+            while i <= current_block_number.into() && j < remaining_proofs_in_epoch {
+                let path =
+                    PathBuf::from(format!("{}/{}_{}.json", blocks_dir.display(), FILENAME, i));
                 info!("submitting proof {}", i);
                 let file = File::open(&path)?;
                 let reader = BufReader::new(file);
                 let block: VDFProof = serde_json::from_reader(reader)?;
-                let view = commit_proof_tx(
-                    &tx_params, block, is_operator
-                )?;
+                let view = commit_proof_tx(&tx_params, block, is_operator)?;
                 match eval_tx_status(view) {
-                    Ok(_) => {},
+                    Ok(_) => {}
                     Err(e) => {
-                      warn!("WARN: could not fetch TX status, continuing to next block in backlog after 30 seconds. Message: {:?} ", e);
-                      thread::sleep(time::Duration::from_millis(30_000));
-                    },
+                        warn!("WARN: could not fetch TX status, continuing to next block in backlog after 30 seconds. Message: {:?} ", e);
+                        break;
+                    }
                 };
                 i = i + 1;
+                j = j + 1;
             }
         }
     }
     Ok(())
 }
 
-/// returns remote tower height
-pub fn get_remote_tower_height(tx_params: &TxParams) -> Result<i128, Error> {
+/// returns remote tower state
+pub fn get_remote_state(tx_params: &TxParams) -> Result<TowerStateResourceView, Error> {
     let client = DiemClient::new(tx_params.url.clone(), tx_params.waypoint).unwrap();
-    info!("Fetching remote tower height: {}, {}",
-        tx_params.url.clone(), tx_params.owner_address.clone()
+    println!(
+        "Fetching remote tower state: {}, {}",
+        tx_params.url.clone(),
+        tx_params.owner_address.clone()
     );
     let remote_state = client.get_miner_state(&tx_params.owner_address);
     match remote_state {
-        Ok( s ) => { match s {
-            Some(remote_state) => {
-                Ok(remote_state.verified_tower_height.into())
-            },
+        Ok(s) => match s {
+            Some(remote_state) => Ok(remote_state),
             None => {
-                static MSG: &str = "Info: Received response but no remote state found. Exiting.";
-                info!("{}", MSG);
-                bail!(MSG)
+                println!("Info: Received response but no remote state found. Exiting.");
+                bail!("Error getting resourcev view")
             }
-        } },
-        Err( _ ) => {
-            // error info returned -> tower is not yet on chain, so the height is 0
-            Ok(-1)
         },
+        Err(_) => {
+            // error info returned -> tower is not yet on chain, so the height is 0
+            bail!("Account is not yet on chain")
+        }
     }
 }
-


### PR DESCRIPTION

## Motivation
The issue #1 was found by Barmalei and he suggested the fix as well. While working on #1, I came across issue #2.

There are couple of problems with tower backlog code:
1. tower can submit more than 72 proofs per epoch, however any proofs beyond the first 72 will be rejected with MoveAbort error. Looking in the explorer, this is a fairly frequent error and might contribute to a recent network problems when a bunch of miners accumulated proofs and were unable to send them, when then public node was available submitted all at once and kept sending causing MoveAbort errors thus congesting the network  
2. If a proof cannot be submitted , backlog code selects the second proof in the backlog, thus violating sequence of proofs. This behavior makes no sense, since this proof will never be accepted (since previous has not been sent). This problem was also reported during network incident when proofs were sent out of order , very likely due to this bug.
The fix is to
1. keep track of how many proofs were sent and do not go over 72
2. break backlog if submission error is encountered.
One gotcha found is that count_proofs_in_epoch is not necessarily proofs submitted in the current epoch, thus additional check is required to be able to use this field.

### Have you read the [Contributing Guidelines on pull requests] yes


## Test Plan

I tested with a  single miner with a few pre-computed proofs. The code works as expected. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
