### PR TITLE
Fix VFN compile error, update doc

### DIFF
--- a/ol/changelog/5_0_8.md
+++ b/ol/changelog/5_0_8.md
@@ -22,18 +22,19 @@ make bins install
 Recreate network configs
 ```
 # backup validator config
-mv ~/.0L/validator.node.yaml ~/.0L/validator.node.yaml.bak_20221204
+mv ~/.0L/validator.node.yaml ~/.0L/validator.node.yaml.bak_20220104
 
 # create the new validator yaml. This will overwrite previous.
-ol config --val
+ol init --val
 
 # create settings for the VFN, private fullnode
-ol config --vfn
+ol init --vfn
 
 # next, copy the ~/.0L/vfn.node.yaml to the host machine of the fullnode.
 
-<stop diem-node>
-<restart diem-node>
+<stop diem-node if running>
+<start diem-node with validator.node.yaml on validator, and vfn.node.yml on fullnode>
+
 
 ```
 

--- a/ol/txs/src/commands/autopay_batch_cmd.rs
+++ b/ol/txs/src/commands/autopay_batch_cmd.rs
@@ -49,7 +49,7 @@ impl Runnable for AutopayBatchCmd {
             },
         };
         println!("Latest Autopay id: {:?}", &start_id);
-        node.refresh_chain_info()?;
+        node.refresh_chain_info();
         let epoch = node.vitals.chain_view.unwrap().epoch;
         println!("The current epoch is: {}\n", epoch);
         


### PR DESCRIPTION
## Motivation

I was testing out the VFN changes. I found a compile error that needed to be fixed to proceed (`refresh_chain_info` no longer returns a Result), and a necessary update to the doc to be able to run the upgrade instructions.

## Test Plan

N/A