### PR TITLE
[docs] add chroot binary build instructions to validation node setup tutorial

### DIFF
--- a/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_hard_mode.md
@@ -131,15 +131,6 @@ mount
 ls /root
 ```
 
-Mount `/proc` **[in sandbox]**:
-```
-# note: if you reboot the machine you will need to redo this
-mount none /proc -t proc
-# check mounts again
-mount
-# should give: none on /proc type proc (rw,relatime)
-```
-
 Configure source list for apt **[in sandbox]**:
 ```
 cat <<EOT > /etc/apt/sources.list
@@ -151,6 +142,15 @@ EOT
 Update apt index **[in sandbox]**:
 ```
 apt update
+```
+
+Mount `/proc` and populate `/dev` **[in sandbox]**:
+```
+# note: if you reboot the machine you will need to redo this
+mount none /proc -t proc
+
+apt install makedev
+mount devpts /dev/pts -t devpts
 ```
 
 Prepare build tooling **[in sandbox]**:


### PR DESCRIPTION
## Motivation
Following the onboarding tutorial I tried a slightly different approach using chroot facility which IMO helps to improve security and maintainability of nodes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

run steps on a clear Ubuntu box (e.g. inside VirtuaBox)

## Related PRs

none

