### PR TITLE
[onboarding] Update validator easy mode so it doesn't panic

### DIFF
--- a/ol/documentation/node-ops/validators/validator_onboarding_easy_mode.md
+++ b/ol/documentation/node-ops/validators/validator_onboarding_easy_mode.md
@@ -9,10 +9,31 @@ You can optionally do [Hard Mode](validator_onboarding_hard_mode.md), and build 
 ### Things you will need:
 
 - A cloud virtual machine running Linux Ubuntu 20.4, with 16GB Ram, and 4 Cores.
+- A user on that machine named `node`
 
 Settings for the host:
 - You need to set a *static* IP address for that host.
 - You need to open ports 6179, 6180, 8080, 3030 on the host
+
+# 0. Prepare environment
+> Note: easy mode probably shouldn't require these steps, but will fail otherwise.
+
+### Create the linux user that will run the 0L services.
+
+We will create a user called `node` which has no password (can only be accessed initially by sudo).
+```
+sudo useradd node -m -s /bin/bash
+```
+### Become the `node` user
+```
+sudo su node
+
+# you are now in the node user
+```
+
+### Clone this repo: 
+
+`git clone https://github.com/OLSF/libra.git`
 
 
 # 1. Install binaries


### PR DESCRIPTION
It looks like the onboard agent has hard-wired folder paths (brought in from `CARGO_MANIFEST_DIR` at compile time; if users follow these instructions it will fail here:

https://github.com/OLSF/libra/blob/e68acaf21d81f93c7ab123616cff07fadbb93fe9/config/management/genesis/src/ol_node_files.rs#L489

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

When following easy mode, it didn't work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

go through doc.

## Related PRs

Code that could be fixed instead of docs being changed is here: https://github.com/OLSF/libra/blob/e68acaf21d81f93c7ab123616cff07fadbb93fe9/config/management/genesis/src/ol_node_files.rs#L489-L504


