### PR TITLE
Introduce new parameter to omit checking on-chain state for submission of first proof

### DIFF
--- a/ol/documentation/node-ops/tower_mining_VDF_proofs.md
+++ b/ol/documentation/node-ops/tower_mining_VDF_proofs.md
@@ -42,6 +42,14 @@ ol init -u http://<ip-of-a-fullnode>:8080
 onboard user
 ```
 
+To submit the first proof (proof_0.json), you need to start the tower app using a special parameter:
+
+```
+tower start -o -b
+```
+
+After the successful first transfer, continue with starting the tower app (see below).
+
 
 ## Start the tower app
 The tower app will produce VDF proofs or submit proofs, which are created and not yet submitted. The first block to be created is proof_1.json (which takes as the preimage input the sha256 hash of proof_0.json)

--- a/ol/tower/src/proof.rs
+++ b/ol/tower/src/proof.rs
@@ -90,6 +90,7 @@ pub fn mine_and_submit(
     config: &AppCfg,
     tx_params: TxParams,
     is_operator: bool,
+    omit_remote_check: bool,
 ) -> Result<(), Error> {
     // get the location of this miner's blocks
     let mut blocks_dir = config.workspace.node_home.clone();
@@ -115,7 +116,7 @@ pub fn mine_and_submit(
             );
 
             // submits backlog to client
-            match backlog::process_backlog(&config, &tx_params, is_operator) {
+            match backlog::process_backlog(&config, &tx_params, is_operator, omit_remote_check) {
                 Ok(()) => println!("Success: Proof committed to chain"),
                 Err(e) => {
                     // don't stop on tx errors


### PR DESCRIPTION
As discussed in the discord channel, it is currently not possible to submit the genesis proof for a freshly created account purely using the tower app