### PR TITLE
Always read mnemonic from env to allow automation (e.g.: Cloud Native)

### DIFF
--- a/ol/keys/src/wallet.rs
+++ b/ol/keys/src/wallet.rs
@@ -66,12 +66,12 @@ pub fn get_account_from_wallet(
 pub fn get_account_from_prompt() -> (AuthenticationKey, AccountAddress, WalletLibrary) {
     println!("Enter your 0L mnemonic:");
 
-    let test_env_mnem = env::var("MNEM");
-    // if we are in debugging or CI mode
-    let mnem = match *IS_TEST && test_env_mnem.is_ok() {
+    let env_mnem = env::var("MNEM");
+    // if we are in debugging, CI mode or in an automated environment (e.g.: k8s)
+    let mnem = match env_mnem.is_ok() {
         true => {
-            println!("Debugging mode, using mnemonic from env variable, $MNEM");
-            test_env_mnem.unwrap().trim().to_string()
+            println!("Using mnemonic from env variable, $MNEM");
+            env_mnem.unwrap().trim().to_string()
         }
         false => match rpassword::read_password_from_tty(Some("\u{1F511} ")) {
             Ok(read) => read,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
We want to scale and automate the deployments of nodes, miners and validators. This will require removing all the user prompts in favor of reading the input from the environment. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Tested running tower, ol and onboarding with and without MNEM set. Verified that:
- If the var is not set there is no change in the behavior
- If the var is set all the commands work as if the mnemonic was manually entered

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
