### PR TITLE
[tools] rpc-playlist initialization with ol init

### DIFF
--- a/ol/cli/src/commands/init_cmd.rs
+++ b/ol/cli/src/commands/init_cmd.rs
@@ -18,7 +18,7 @@ use diem_types::waypoint::Waypoint;
 use diem_wallet::WalletLibrary;
 use fs_extra::file::{copy, CopyOptions};
 use ol_keys::{scheme::KeyScheme, wallet};
-use ol_types::{config::fix_missing_fields, fixtures, rpc_playlist::FullnodePlaylist};
+use ol_types::{config::{fix_missing_fields, parse_toml}, fixtures, rpc_playlist};
 use std::process::exit;
 use std::{fs, path::PathBuf};
 use url::Url;
@@ -52,7 +52,7 @@ pub struct InitCmd {
 
     /// Set the upstream peers playlist from an http served playlist file
     #[options(help = "Use a playlist.json file hosted online to set the upstream_peers field in 0L.toml")]
-    rpc_playlist: Option<Url>,
+    rpc_playlist: Option<String>, // Using string so that the user can use a default upstream
 
     /// Search and get seed peers from chain
     #[options(help = "Get seed fullnode peers from chain")]
@@ -86,8 +86,6 @@ pub struct InitCmd {
 impl Runnable for InitCmd {
     /// Print version message
     fn run(&self) {
-        let cfg = app_config().clone();
-
         // TODO: This has no effect. This command will not load if the 0L.toml is malformed.
         // this is an Abscissa issue.
         // even with serde deny_unknown disabled the app will crash.
@@ -141,14 +139,35 @@ impl Runnable for InitCmd {
             }
         }
         
-        if let Some(url) = self.rpc_playlist {
-           match FullnodePlaylist::http_fetch_playlist(url){
+        if let Some(url) = self.rpc_playlist.as_ref() {
+          
+
+          // try to parse it, otherwise get_known_fullnodes will use a default playlist
+          let playlist_url: Option<Url> = url.parse().ok();
+
+           match rpc_playlist::get_known_fullnodes(playlist_url){
               Ok(f) => {
 
-                let cfg_path = self.app_cfg_path.unwrap_or(cfg.workspace.node_home.join("0L.toml"));
-                parse_toml(cfg_path);
-                // read AppCfg
-                // write AppCfg
+                let mut new_cfg = match parse_toml(self.app_cfg_path.clone()) { // if None path just use default
+                    Ok(c) => c,
+                    Err(e) => {
+                      println!("could not parse app config toml file, exiting. Message: {:?}", e );
+                      exit(1);
+                    },
+                };
+                new_cfg.profile.upstream_nodes = f.get_urls();
+
+                println!("peers found:");
+                new_cfg.profile.upstream_nodes.iter()
+                .for_each(|u| {
+                  println!("{}", u.as_str())
+                });
+
+                // println!("peers found: {:?}", new_cfg.profile.upstream_nodes);
+
+                new_cfg.save_file();
+                println!("Upstream RPC peers updated in 0L.toml");
+                return
               },
               Err(e) => {
                 println!("could not read playlists from {:?}, exiting. Message: {:?}", url, e);

--- a/ol/cli/src/commands/start_cmd.rs
+++ b/ol/cli/src/commands/start_cmd.rs
@@ -4,7 +4,7 @@ use std::process::exit;
 
 use abscissa_core::{Command, Options, Runnable};
 use crate::{
-  check::{self, pilot}, entrypoint, node::client, node::node::Node, prelude::app_config
+  check, entrypoint, node::client, node::node::Node, prelude::app_config
 };
 
 /// `start` subcommand
@@ -12,16 +12,9 @@ use crate::{
 #[derive(Command, Debug, Options)]
 pub struct StartCmd {
     /// Silent mode, defaults to verbose
-    #[options(short = "s", help = "silent mode, no prints")]
-    silent: bool,
-  
-    /// Check if DB needs to be restored.
-    #[options(short = "r", help = "check if DB bootstraps if not will attempt restore")]
-    restore: bool,
+    #[options(short = "q", help = "silent mode, no prints")]
+    quiet: bool,
 
-    // /// Check if DB needs to be restored.
-    // #[options(short = "u", help = "fetches list of fullnode peers from onchain discovery, and saves to 0L.toml")]
-    // refresh_upstream: bool,
 }
 
 impl Runnable for StartCmd {
@@ -39,19 +32,6 @@ impl Runnable for StartCmd {
         };
         let mut node = Node::new(client, &cfg, is_swarm);
         
-        // if *&self.refresh_upstream {
-        //     // fix 0L.toml file
-        //     let cfg_path = cfg.workspace.node_home;
-        //     match node.refresh_peers_update_toml(cfg_path.join("0L.toml")) {
-        //         Ok(_) => return,
-        //         Err(e) => {
-        //           println!("ERROR: unable to update seed peers, message:{:?}", e);
-        //           exit(1);
-        //         },
-        //     };
-            
-        // };
-        if *&self.restore { pilot::maybe_restore_db(&mut node, !self.silent); }
-        check::runner::run_checks(&mut node, true ,true, !self.silent, !self.silent);
+        check::runner::run_checks(&mut node, true, true, !self.quiet, !self.quiet);
     }
 }

--- a/ol/cli/src/node/account.rs
+++ b/ol/cli/src/node/account.rs
@@ -102,7 +102,7 @@ impl Node {
     }
 
     /// Get account auto pay resource
-    pub fn get_autopay_view(&mut self, account: AccountAddress) -> Result<AutoPayView, Error> {
+    pub fn get_autopay_view(&self, account: AccountAddress) -> Result<AutoPayView, Error> {
         let state = self.get_account_state(account)?;
          match state.get_resource_impl::<AutoPayResource>(
                 AutoPayResource::resource_path().as_slice()
@@ -114,7 +114,7 @@ impl Node {
     }
 
     /// Enrich with notes from dictionary file
-    fn enrich_note(&mut self, mut autopay: AutoPayView) -> AutoPayView {
+    fn enrich_note(&self, mut autopay: AutoPayView) -> AutoPayView {
         let dic = self.load_account_dictionary();
         for payment in autopay.payments.iter_mut()  {
             payment.note = Some(dic.get_note_for_address(payment.payee));
@@ -124,7 +124,7 @@ impl Node {
 
     /// Get validator config view
     pub fn get_validator_config(
-        &mut self, address: AccountAddress
+        &self, address: AccountAddress
     ) -> Result<ValidatorConfigView, Error> {
         let state = self.get_account_state(address)?;
         match state
@@ -132,7 +132,7 @@ impl Node {
           ValidatorConfigResource::resource_path().as_slice()
           )? {
             Some(res) => {
-              let mut view = res.get_view();
+              let mut view = res.get_view().clone();
 
                 let operator = view.operator_account;
                 if let Some(o) = operator {
@@ -146,7 +146,7 @@ impl Node {
     }
 
     /// Query if valid account has balance greater than zero
-    pub fn has_positive_balance(&mut self, address: AccountAddress) -> bool {
+    pub fn has_positive_balance(&self, address: AccountAddress) -> bool {
         match self.get_account_balance(address) {
             Some(v) => v > 0.0,
             None => false,
@@ -164,7 +164,7 @@ impl Node {
     }
 
     /// Get account balance
-    pub fn get_account_balance(&mut self, address: AccountAddress) -> Option<f64> {
+    pub fn get_account_balance(&self, address: AccountAddress) -> Option<f64> {
         match self.client.get_account(&address) {
             Ok(Some(account_view)) => Some(get_balance(account_view)),
             Ok(None) => None,
@@ -190,7 +190,7 @@ impl Node {
     }
 
     /// get any account state with client
-    pub fn get_account_state(&mut self, address: AccountAddress) -> Result<AccountState, Error> {
+    pub fn get_account_state(&self, address: AccountAddress) -> Result<AccountState, Error> {
         let (blob, _ver) = self.client.get_account_state_blob(&address)?;
         if let Some(account_blob) = blob {
             match AccountState::try_from(&account_blob) {

--- a/ol/cli/src/node/autopay_view.rs
+++ b/ol/cli/src/node/autopay_view.rs
@@ -1,16 +1,15 @@
 //! `chain_info`
-use anyhow::{bail, Error};
-use chrono::Utc;
-use diem_json_rpc_client::views::OracleUpgradeStateView;
+
+
+
 use diem_types::{
-    account_address::AccountAddress, account_state::AccountState,
-    ol_validators_stats::ValidatorsStatsResource, waypoint::Waypoint,
+    account_address::AccountAddress,
 };
-use ol_types::{autopay::AutoPayView, validator_config::ValidatorConfigView};
+
 
 use super::{node::Node, chain_view::ValidatorView};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom};
+use std::{collections::HashMap};
 
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/ol/cli/src/node/autopay_view.rs
+++ b/ol/cli/src/node/autopay_view.rs
@@ -1,0 +1,98 @@
+//! `chain_info`
+use anyhow::{bail, Error};
+use chrono::Utc;
+use diem_json_rpc_client::views::OracleUpgradeStateView;
+use diem_types::{
+    account_address::AccountAddress, account_state::AccountState,
+    ol_validators_stats::ValidatorsStatsResource, waypoint::Waypoint,
+};
+use ol_types::{autopay::AutoPayView, validator_config::ValidatorConfigView};
+
+use super::{node::Node, chain_view::ValidatorView};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, convert::TryFrom};
+
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+///
+pub struct PayeeStats {
+    ///
+    pub address: AccountAddress,
+    ///
+    pub note: String,
+    ///
+    pub balance: f64,
+    ///
+    pub payers: u64,
+    ///
+    pub average_percent: f64,
+    ///
+    pub sum_percentage: u64,
+    ///
+    pub all_percentage: f64,
+}
+
+
+impl Node {
+    /// Get all percentage recurring payees stats
+    pub fn get_autopay_watch_list(&mut self, vals: Vec<ValidatorView>) -> Option<Vec<PayeeStats>> {
+        let mut payees: HashMap<AccountAddress, PayeeSums> = HashMap::new();
+        let mut total: u64 = 0;
+
+        struct PayeeSums {
+            pub amount: u64,
+            pub payers: u64,
+        }
+
+        // iterate over all validators
+        for val in vals.iter() {
+            if let Some(ap) = &val.autopay {
+                // iterate over all autopay instructions
+                let mut val_payees: HashMap<AccountAddress, u64> = HashMap::new();
+                for payment in ap.payments.iter() {
+                    if payment.is_percent_of_change() {
+                        total += payment.amt;
+                        *val_payees.entry(payment.payee).or_insert(0) += payment.amt;
+                    }
+                }
+                // sum payers and amount
+                for (payee, amount) in val_payees.iter() {
+                    let payee_sums = payees.get_mut(&payee);
+                    match payee_sums {
+                        Some(p) => {
+                            p.amount = p.amount + amount;
+                            p.payers = p.payers + 1;
+                        }
+                        None => {
+                            payees.insert(
+                                *payee,
+                                PayeeSums {
+                                    amount: *amount,
+                                    payers: 1,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // collect payees stats
+        let dict = self.load_account_dictionary();
+        let ret = payees
+            .iter()
+            .map(|(payee, stat)| PayeeStats {
+                note: dict.get_note_for_address(*payee),
+                address: *payee,
+                payers: stat.payers,
+                average_percent: stat.amount as f64 / stat.payers as f64,
+                balance: self.get_account_balance(*payee).unwrap_or(0.0),
+                sum_percentage: stat.amount,
+                all_percentage: (stat.amount * 10000) as f64 / total as f64,
+            })
+            .collect();
+        Some(ret)
+    }
+}
+
+

--- a/ol/cli/src/node/chain_view.rs
+++ b/ol/cli/src/node/chain_view.rs
@@ -11,7 +11,7 @@ use ol_types::{autopay::AutoPayView, validator_config::ValidatorConfigView};
 
 use super::{node::Node, dictionary::AccountDictionary, autopay_view::PayeeStats};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom};
+use std::{convert::TryFrom};
 
 /// name of chain info key for db
 pub const CHAIN_INFO_DB_KEY: &str = "chain_info";

--- a/ol/cli/src/node/chain_view.rs
+++ b/ol/cli/src/node/chain_view.rs
@@ -1,17 +1,16 @@
 //! `chain_info`
-use anyhow::{Error, bail};
+use anyhow::{bail, Error};
 use chrono::Utc;
-use diem_json_rpc_client::views::{OracleUpgradeStateView};
+use diem_json_rpc_client::views::OracleUpgradeStateView;
 use diem_types::{
-    account_address::AccountAddress, 
-    account_state::AccountState, waypoint::Waypoint,
-    ol_validators_stats::ValidatorsStatsResource
+    account_address::AccountAddress, account_state::AccountState,
+    ol_validators_stats::ValidatorsStatsResource, waypoint::Waypoint,
 };
-use ol_types::{validator_config::ValidatorConfigView, autopay::AutoPayView};
+use ol_types::{autopay::AutoPayView, validator_config::ValidatorConfigView};
 
-use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, collections::HashMap};
 use super::node::Node;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, convert::TryFrom};
 
 /// name of chain info key for db
 pub const CHAIN_INFO_DB_KEY: &str = "chain_info";
@@ -21,333 +20,358 @@ pub const VAL_INFO_DB_KEY: &str = "val_info";
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 /// ChainInfo struct
 pub struct ChainView {
-  /// epoch
-  pub epoch: u64,
-  /// height/version
-  pub height: u64,
-  /// validator count
-  pub validator_count: u64,
-  /// total supply of GAS
-  pub total_supply: u64,
-  /// latest epoch change time
-  pub latest_epoch_change_time: u64,
-  /// epoch_progress
-  pub epoch_progress: f64,
-  /// waypoint
-  pub waypoint: Option<Waypoint>,
-  /// upgrade
-  pub upgrade: Option<OracleUpgradeStateView>,
-  /// validator view
-  pub validator_view: Option<Vec<ValidatorView>>,
-  /// validators stats
-  pub validators_stats: Option<ValidatorsStatsResource>,
-  /// audit stats
-  pub vals_config_stats: Option<ValsConfigStats>,
-  /// autopay payees percentage recurring stats
-  pub autopay_watch_list: Option<Vec<PayeeStats>>, 
+    /// epoch
+    pub epoch: u64,
+    /// height/version
+    pub height: u64,
+    /// validator count
+    pub validator_count: u64,
+    /// total supply of GAS
+    pub total_supply: u64,
+    /// latest epoch change time
+    pub latest_epoch_change_time: u64,
+    /// epoch_progress
+    pub epoch_progress: f64,
+    /// waypoint
+    pub waypoint: Option<Waypoint>,
+    /// upgrade
+    pub upgrade: Option<OracleUpgradeStateView>,
+    /// validator view
+    pub validator_view: Option<Vec<ValidatorView>>,
+    /// validators stats
+    pub validators_stats: Option<ValidatorsStatsResource>,
+    /// audit stats
+    pub vals_config_stats: Option<ValsConfigStats>,
+    /// autopay payees percentage recurring stats
+    pub autopay_watch_list: Option<Vec<PayeeStats>>,
 }
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 /// Validator info struct
 pub struct ValidatorView {
-  /// account address
-  pub account_address: String,
-  /// public key
-  pub pub_key: String,
-  /// voting power
-  pub voting_power: u64,
-  /// full node ip
-  pub full_node_ip: String,
-  /// validator ip
-  pub validator_ip: String,
-  /// tower height
-  pub tower_height: u64,
-  /// tower epoch
-  pub tower_epoch: u64,
-  /// proof counts in current epoch
-  pub count_proofs_in_epoch: u64,
-  /// epoch validating and mining
-  pub epochs_validating_and_mining: u64,
-  /// contiguous epochs of mining
-  pub contiguous_epochs_validating_and_mining: u64,
-  /// epoch count since creation
-  pub epochs_since_last_account_creation: u64,
-  /// total count votes in current epoch
-  pub vote_count_in_epoch: u64,
-  /// total block propositions in current epoch
-  pub prop_count_in_epoch: u64,
-  /// validator config in the chain
-  pub validator_config: Option<ValidatorConfigView>,
-  /// autopay instructions
-  pub autopay: Option<AutoPayView>,
-  /// note
-  pub note: String,
+    /// account address
+    pub account_address: String,
+    /// public key
+    pub pub_key: String,
+    /// voting power
+    pub voting_power: u64,
+    /// full node ip
+    pub full_node_ip: String,
+    /// validator ip
+    pub validator_ip: String,
+    /// tower height
+    pub tower_height: u64,
+    /// tower epoch
+    pub tower_epoch: u64,
+    /// proof counts in current epoch
+    pub count_proofs_in_epoch: u64,
+    /// epoch validating and mining
+    pub epochs_validating_and_mining: u64,
+    /// contiguous epochs of mining
+    pub contiguous_epochs_validating_and_mining: u64,
+    /// epoch count since creation
+    pub epochs_since_last_account_creation: u64,
+    /// total count votes in current epoch
+    pub vote_count_in_epoch: u64,
+    /// total block propositions in current epoch
+    pub prop_count_in_epoch: u64,
+    /// validator config in the chain
+    pub validator_config: Option<ValidatorConfigView>,
+    /// autopay instructions
+    pub autopay: Option<AutoPayView>,
+    /// note
+    pub note: String,
 }
 
 /// Validators config stats
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 pub struct ValsConfigStats {
-  /// total #vals in the stats
-  pub total_vals: usize,
-  /// total of vals with autopay set
-  pub count_vals_with_autopay: u64,
-  /// total of vals with operator account
-  pub count_vals_with_operator: u64,
-  /// total of vals having operator with balance greater than zero
-  pub count_positive_balance_operators: u64,
-  /// percentage of vals with autopay set
-  pub percent_vals_with_autopay: f64,
-  /// percentage of vals with operator account
-  pub percent_vals_with_operator: f64,
-  /// percentage of vals having operator with balance greater than zero
-  pub percent_positive_balance_operators: f64,
+    /// total #vals in the stats
+    pub total_vals: usize,
+    /// total of vals with autopay set
+    pub count_vals_with_autopay: u64,
+    /// total of vals with operator account
+    pub count_vals_with_operator: u64,
+    /// total of vals having operator with balance greater than zero
+    pub count_positive_balance_operators: u64,
+    /// percentage of vals with autopay set
+    pub percent_vals_with_autopay: f64,
+    /// percentage of vals with operator account
+    pub percent_vals_with_operator: f64,
+    /// percentage of vals having operator with balance greater than zero
+    pub percent_positive_balance_operators: f64,
 }
 
 impl Node {
-  // TODO: this should return a result and no functions below should use unwrap()
-  /// fetch state from system address 0x0
-  pub fn refresh_chain_info(&mut self) -> Result<(ChainView, Vec<ValidatorView>), Error> {
-    // let mut client = client::pick_client();
-    let (blob, _version) = match self.client
-      .get_account_state_blob(&AccountAddress::ZERO) {
-        Ok(t)=> t,
-        Err(_) => (None, 0),
-    };
-    let mut cs = ChainView::default();
+    // TODO: this should return a result and no functions below should use unwrap()
+    /// fetch state from system address 0x0
+    pub fn refresh_chain_info(&mut self) -> Result<(ChainView, Vec<ValidatorView>), Error> {
+        // let mut client = client::pick_client();
+        let (blob, _version) = match self.client.get_account_state_blob(&AccountAddress::ZERO) {
+            Ok(t) => t,
+            Err(_) => (None, 0),
+        };
+        let mut cs = ChainView::default();
 
-    // TODO: This is duplicated with check.rs
-    let _ = self.client.update_and_verify_state_proof();
-    
-    cs.waypoint = self.client.waypoint().ok();
+        // TODO: This is duplicated with check.rs
+        self.client.update_and_verify_state_proof()?;
 
-    if let Some(account_blob) = blob {
-      let account_state = AccountState::try_from(&account_blob).unwrap();
-      let meta = self.client.get_metadata().unwrap();
-      cs.epoch = account_state
-        .get_configuration_resource()
-        .unwrap()
-        .unwrap()
-        .epoch();
+        cs.waypoint = self.client.waypoint().ok();
 
-      cs.validator_count = account_state
-        .get_validator_set()
-        .unwrap()
-        .unwrap()
-        .payload()
-        .len() as u64;
+        if let Some(account_blob) = blob {
+            let account_state = AccountState::try_from(&account_blob)?;
+            let meta = self.client.get_metadata()?;
+            cs.epoch = account_state
+                .get_configuration_resource()?
+                .unwrap()
+                .epoch();
 
-      // Get vals stats
-      let validators_stats = account_state
-        .get_validators_stats()
-        .unwrap()
-        .unwrap();
+            cs.validator_count = account_state
+                .get_validator_set()?
+                .unwrap()
+                .payload()
+                .len() as u64;
 
-      // Calculate Epoch Progress
-      let ts = account_state
-        .get_configuration_resource()
-        .unwrap()
-        .unwrap()
-        .last_reconfiguration_time() as i64
-        / 1000000;
-      let now = Utc::now().timestamp();
+            // Get vals stats
+            let validators_stats = account_state.get_validators_stats()?.unwrap();
 
-      match meta.chain_id {
-        // testnet has faster epochs
-        4 => cs.epoch_progress = (now - ts) as f64 / 61f64, // 1 minute
-        // for main net
-        _ => cs.epoch_progress = (now - ts) as f64 / 86401f64, // 24 hours
-      }
-      if cs.epoch_progress > 1f64 {
-        cs.epoch_progress = 0f64;
-      };
+            // Calculate Epoch Progress
+            let ts = account_state
+                .get_configuration_resource()?
+                .unwrap()
+                .last_reconfiguration_time() as i64
+                / 1000000;
+            let now = Utc::now().timestamp();
 
-      if let Some(first) = account_state
-        .get_registered_currency_info_resources()
-        .unwrap()
-        .first()
-      {
-        cs.total_supply = (first.total_value() / first.scaling_factor() as u128) as u64;
-      }
-
-      cs.height = meta.version;
-
-      cs.upgrade = self.client.get_oracle_upgrade_state().expect(
-        "could not get upgrade oracle view"
-      );
-
-      let dict = self.load_account_dictionary();
-      let validators: Vec<ValidatorView> = account_state
-        .get_validator_set()
-        .unwrap()
-        .unwrap()
-        .payload()
-        .iter()
-        .map(|v| {
-          let full_node_ip = match v.config().fullnode_network_addresses() {
-            Ok(ips) => {
-              if !ips.is_empty() {
-                ips.last().unwrap().to_string()
-              } else {
-                "--".to_string()
-              }
+            match meta.chain_id {
+                // testnet has faster epochs
+                4 => cs.epoch_progress = (now - ts) as f64 / 61f64, // 1 minute
+                // for main net
+                _ => cs.epoch_progress = (now - ts) as f64 / 86401f64, // 24 hours
             }
-            Err(_) => "--".to_string(),
-          };
-          let validator_ip = match v.config().validator_network_addresses() {
-            Ok(ips) => {
-              if !ips.is_empty() {
-                ips.get(0).unwrap().seq_num().to_string()
-              } else {
-                "--".to_string()
-              }
+            if cs.epoch_progress > 1f64 {
+                cs.epoch_progress = 0f64;
+            };
+
+            if let Some(first) = account_state
+                .get_registered_currency_info_resources()?
+                .first()
+            {
+                cs.total_supply = (first.total_value() / first.scaling_factor() as u128) as u64;
             }
-            Err(_) => "--".to_string(),
-          };
-          let ms = self
-            .client
-            .get_miner_state(&v.account_address().clone())
-            .unwrap()
-            .unwrap();
 
-          let validator_stats = validators_stats.get_validator_current_stats(v.account_address().clone());
-          let val_config = self.get_validator_config(v.account_address().clone());
-          let autopay = self.get_autopay_view(v.account_address().clone());
+            cs.height = meta.version;
 
-          ValidatorView {
-            account_address: v.account_address().to_string(),
-            voting_power: v.consensus_voting_power(),
-            full_node_ip,
-            pub_key: v.consensus_public_key().to_string(),
-            validator_ip,
+            cs.upgrade = self
+                .client
+                .get_oracle_upgrade_state()?;
 
-            tower_height: ms.verified_tower_height,
-            tower_epoch: ms.latest_epoch_mining,
+            let dict = self.load_account_dictionary();
+            let validators: Vec<ValidatorView> = account_state
+                .get_validator_set()?
+                .unwrap()
+                .payload()
+                .iter()
+                .filter_map(|v| {
+                    let full_node_ip = match v.config().fullnode_network_addresses() {
+                        Ok(ips) => {
+                            if ips.len() > 0 {
+                                ips.last().unwrap().to_string()
+                            } else {
+                                "--".to_string()
+                            }
+                        }
+                        Err(_) => "--".to_string(),
+                    };
+                    let validator_ip = match v.config().validator_network_addresses() {
+                        Ok(ips) => {
+                            if ips.len() > 0 {
+                                match ips.get(0) {
+                                    Some(i) => i.seq_num().to_string(),
+                                    None => "--".to_string(),
+                                }
+                                
+                            } else {
+                                "--".to_string()
+                            }
+                        }
+                        Err(_) => "--".to_string(),
+                    };
+                    let ms = match self
+                        .client
+                        .get_miner_state(&v.account_address().clone()) {
+                            Ok(Some(ts)) => ts,
+                            _=> return None,
+                        };
+  
 
-            count_proofs_in_epoch: ms.count_proofs_in_epoch,
-            epochs_validating_and_mining: ms.epochs_validating_and_mining,
-            contiguous_epochs_validating_and_mining: ms
-              .contiguous_epochs_validating_and_mining,
-            epochs_since_last_account_creation: ms.epochs_since_last_account_creation,
-            vote_count_in_epoch: validator_stats.vote_count,
-            prop_count_in_epoch: validator_stats.prop_count,
-            validator_config: val_config,
-            autopay: autopay,
-            note: dict.get_note_for_address(*v.account_address())
-          }
-        })
-        .collect();
-      
-      cs.validator_view = Some(validators.clone());
-      cs.validators_stats = Some(validators_stats);
-      cs.vals_config_stats = Some(calc_config_stats(cs.validator_view.clone().unwrap()));
-      cs.autopay_watch_list = self.get_autopay_watch_list(validators.clone());
-            
-      self.vitals.chain_view = Some(cs.clone());
+                    let validator_stats = match validators_stats
+                      .get_validator_current_stats(v.account_address().clone()){
+                            Ok(v) => v,
+                            _=> return None,
+                        };
+  
+                    
+                    let val_config = match self.get_validator_config(v.account_address().clone()) {
+                        Ok(v) => v,
+                        _ => return None,
+                    };
 
-      return Ok((cs, validators));
-    }
+                    let autopay = match self.get_autopay_view(v.account_address().clone()){
+                        Ok(v) => v,
+                        _ => return None,
+                    };
 
-    bail!("could not get chain info")
-  }
+                    Some(ValidatorView {
+                        account_address: v.account_address().to_string(),
+                        voting_power: v.consensus_voting_power(),
+                        full_node_ip,
+                        pub_key: v.consensus_public_key().to_string(),
+                        validator_ip,
 
-  /// Get all percentage recurring payees stats
-  pub fn get_autopay_watch_list(&mut self, vals: Vec<ValidatorView>) -> Option<Vec<PayeeStats>> {
-    let mut payees: HashMap<AccountAddress, PayeeSums> = HashMap::new();
-    let mut total: u64 = 0;
+                        tower_height: ms.verified_tower_height,
+                        tower_epoch: ms.latest_epoch_mining,
 
-    struct PayeeSums {
-      pub amount: u64,
-      pub payers: u64,
-    }
+                        count_proofs_in_epoch: ms.count_proofs_in_epoch,
+                        epochs_validating_and_mining: ms.epochs_validating_and_mining,
+                        contiguous_epochs_validating_and_mining: ms
+                            .contiguous_epochs_validating_and_mining,
+                        epochs_since_last_account_creation: ms.epochs_since_last_account_creation,
+                        vote_count_in_epoch: validator_stats.vote_count,
+                        prop_count_in_epoch: validator_stats.prop_count,
+                        validator_config: Some(val_config),
+                        autopay: Some(autopay),
+                        note: dict.get_note_for_address(*v.account_address()),
+                    })
+                })
+                .collect();
 
-    // iterate over all validators
-    for val in vals.iter() {
-      if val.autopay.is_some() {
-        // iterate over all autopay instructions
-        let mut val_payees: HashMap<AccountAddress, u64> = HashMap::new();
-        for payment in val.autopay.as_ref().unwrap().payments.iter() {
-          if payment.is_percent_of_change() {
-            total += payment.amt;
-            *val_payees.entry(payment.payee).or_insert(0) += payment.amt;
-          }
+            cs.validator_view = Some(validators.clone());
+            cs.validators_stats = Some(validators_stats);
+            cs.vals_config_stats = Some(calc_config_stats(cs.validator_view.clone().unwrap()));
+            cs.autopay_watch_list = self.get_autopay_watch_list(validators.clone());
+
+            self.vitals.chain_view = Some(cs.clone());
+
+            return Ok((cs, validators));
         }
-        // sum payers and amount
-        for (payee, amount) in val_payees.iter() {
-          let payee_sums = payees.get_mut(&payee);
-          match payee_sums {
-            Some(p) => {
-              p.amount = p.amount + amount;
-              p.payers = p.payers + 1;
-            },
-            None => {
-              payees.insert(*payee, PayeeSums { amount: *amount, payers: 1 });    
-            }
-          }
-        }
-      }
+
+        bail!("could not get chain info")
     }
 
-    
-    // collect payees stats
-    let dict = self.load_account_dictionary();
-    let ret = payees.iter().map(| (payee, stat) | {
-      PayeeStats {
-        note: dict.get_note_for_address(*payee),
-        address: *payee, 
-        payers: stat.payers, 
-        average_percent: stat.amount as f64 / stat.payers as f64,
-        balance: self.get_account_balance(*payee).unwrap_or(0.0), 
-        sum_percentage: stat.amount,
-        all_percentage: (stat.amount * 10000) as f64 / total as f64,
-      }
-    }).collect();
-    Some(ret)
-  }
+    /// Get all percentage recurring payees stats
+    pub fn get_autopay_watch_list(&mut self, vals: Vec<ValidatorView>) -> Option<Vec<PayeeStats>> {
+        let mut payees: HashMap<AccountAddress, PayeeSums> = HashMap::new();
+        let mut total: u64 = 0;
+
+        struct PayeeSums {
+            pub amount: u64,
+            pub payers: u64,
+        }
+
+        // iterate over all validators
+        for val in vals.iter() {
+            if val.autopay.is_some() {
+                // iterate over all autopay instructions
+                let mut val_payees: HashMap<AccountAddress, u64> = HashMap::new();
+                for payment in val.autopay.as_ref().unwrap().payments.iter() {
+                    if payment.is_percent_of_change() {
+                        total += payment.amt;
+                        *val_payees.entry(payment.payee).or_insert(0) += payment.amt;
+                    }
+                }
+                // sum payers and amount
+                for (payee, amount) in val_payees.iter() {
+                    let payee_sums = payees.get_mut(&payee);
+                    match payee_sums {
+                        Some(p) => {
+                            p.amount = p.amount + amount;
+                            p.payers = p.payers + 1;
+                        }
+                        None => {
+                            payees.insert(
+                                *payee,
+                                PayeeSums {
+                                    amount: *amount,
+                                    payers: 1,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // collect payees stats
+        let dict = self.load_account_dictionary();
+        let ret = payees
+            .iter()
+            .map(|(payee, stat)| PayeeStats {
+                note: dict.get_note_for_address(*payee),
+                address: *payee,
+                payers: stat.payers,
+                average_percent: stat.amount as f64 / stat.payers as f64,
+                balance: self.get_account_balance(*payee).unwrap_or(0.0),
+                sum_percentage: stat.amount,
+                all_percentage: (stat.amount * 10000) as f64 / total as f64,
+            })
+            .collect();
+        Some(ret)
+    }
 }
 
 fn calc_config_stats(vals: Vec<ValidatorView>) -> ValsConfigStats {
-  let mut count_autopay = 0;
-  let mut count_operators = 0;
-  let mut count_positive_balance = 0;
+    let mut count_autopay = 0;
+    let mut count_operators = 0;
+    let mut count_positive_balance = 0;
 
-  for val in vals.iter() {
-    let config = val.validator_config.clone().unwrap();
-    if val.autopay.is_some() && val.autopay.as_ref().unwrap().payments.iter().find(| each | each.is_percent_of_change()).is_some() {
-      count_autopay += 1;
+    for val in vals.iter() {
+        let config = val.validator_config.clone().unwrap();
+        if val.autopay.is_some()
+            && val
+                .autopay
+                .as_ref()
+                .unwrap()
+                .payments
+                .iter()
+                .find(|each| each.is_percent_of_change())
+                .is_some()
+        {
+            count_autopay += 1;
+        }
+        if config.operator_account.is_some() {
+            count_operators += 1;
+        }
+        if config.operator_has_balance.is_some() && config.operator_has_balance.unwrap() {
+            count_positive_balance += 1;
+        }
     }
-    if config.operator_account.is_some() {
-      count_operators += 1;
+    ValsConfigStats {
+        total_vals: vals.len(),
+        count_vals_with_autopay: count_autopay,
+        count_vals_with_operator: count_operators,
+        count_positive_balance_operators: count_positive_balance,
+        percent_vals_with_autopay: count_autopay as f64 / vals.len() as f64,
+        percent_vals_with_operator: count_operators as f64 / vals.len() as f64,
+        percent_positive_balance_operators: count_positive_balance as f64 / vals.len() as f64,
     }
-    if config.operator_has_balance.is_some() && config.operator_has_balance.unwrap() {
-      count_positive_balance += 1;
-    } 
-  }
-  ValsConfigStats {
-    total_vals: vals.len(),
-    count_vals_with_autopay: count_autopay,
-    count_vals_with_operator: count_operators,
-    count_positive_balance_operators: count_positive_balance,
-    percent_vals_with_autopay: count_autopay as f64 / vals.len() as f64,
-    percent_vals_with_operator: count_operators as f64 / vals.len() as f64,
-    percent_positive_balance_operators: count_positive_balance as f64 / vals.len() as f64,
-  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 ///
 pub struct PayeeStats {
-  ///
-  pub address: AccountAddress,
-  ///
-  pub note: String,
-  ///
-  pub balance: f64,
-  ///
-  pub payers: u64,
-  ///
-  pub average_percent: f64,
-  ///
-  pub sum_percentage: u64,
-  /// 
-  pub all_percentage: f64,
+    ///
+    pub address: AccountAddress,
+    ///
+    pub note: String,
+    ///
+    pub balance: f64,
+    ///
+    pub payers: u64,
+    ///
+    pub average_percent: f64,
+    ///
+    pub sum_percentage: u64,
+    ///
+    pub all_percentage: f64,
 }

--- a/ol/cli/src/node/dictionary.rs
+++ b/ol/cli/src/node/dictionary.rs
@@ -23,7 +23,7 @@ pub struct AccountDictionaryEntry {
 
 impl Node {
     /// load account dictionary from json file
-    pub fn load_account_dictionary(&mut self) -> AccountDictionary {
+    pub fn load_account_dictionary(&self) -> AccountDictionary {
         let node_home = &self.app_conf.workspace.node_home;
         let dic_path = node_home.join("accounts-dictionary.json");
         match Path::new(&dic_path).exists() {

--- a/ol/cli/src/node/mod.rs
+++ b/ol/cli/src/node/mod.rs
@@ -8,4 +8,5 @@ pub mod client;
 pub mod states;
 pub mod dictionary;
 pub mod refresh_peers;
+pub mod autopay_view;
 // mod transitions;

--- a/ol/cli/src/node/node.rs
+++ b/ol/cli/src/node/node.rs
@@ -48,7 +48,7 @@ pub struct Node {
 
 impl Node {
     /// Create a instance of Check
-    pub fn new(client: DiemClient, conf: &AppCfg, is_swarm: bool) -> Self {
+    pub fn new(client: DiemClient, app_cfg: &AppCfg, is_swarm: bool) -> Self {
         let node_yaml = if is_swarm {
             "node.yaml"
         } else {
@@ -56,8 +56,8 @@ impl Node {
         };
 
         let node_conf = match NodeConfig::load(
-            conf.workspace.node_home.join(node_yaml)
-        ) {
+            app_cfg.workspace.node_home.join(node_yaml)
+        ){
             Ok(c) => Some(c),
             Err(_) => {
               // println!("Warn: could not find a validator config file, trying fullnode");
@@ -73,11 +73,11 @@ impl Node {
 
         return Self {
             client,
-            app_conf: conf.clone(),
+            app_conf: app_cfg.clone(),
             node_conf: node_conf,
             vitals: Vitals {
                 host_state: HostState::new(),
-                account_view: OwnerAccountView::new(conf.profile.account),
+                account_view: OwnerAccountView::new(app_cfg.profile.account),
                 chain_view: None,
                 items: Items::new(false),
                 node_proc: None,

--- a/ol/cli/src/node/node.rs
+++ b/ol/cli/src/node/node.rs
@@ -61,7 +61,7 @@ impl Node {
             Ok(c) => Some(c),
             Err(_) => {
               // println!("Warn: could not find a validator config file, trying fullnode");
-              match NodeConfig::load(conf.workspace.node_home.join("fullnode.node.yaml")) {
+              match NodeConfig::load(app_cfg.workspace.node_home.join("fullnode.node.yaml")) {
                 Ok(c) => Some(c),
                 Err(_) => {
                   // println!("ERROR: could not find any *.node.yaml file. Will start without knowing the Node configs");

--- a/ol/types/src/config.rs
+++ b/ol/types/src/config.rs
@@ -61,10 +61,11 @@ pub struct AppCfg {
 }
 
 /// Get a AppCfg object from toml file
-pub fn parse_toml(path: PathBuf) -> Result<AppCfg, Error> {
-    // let mut config_toml = path.to_str().unwrap().to_owned()).expect("could not parse app config from file");
+pub fn parse_toml(path: Option<PathBuf>) -> Result<AppCfg, Error> {
+    let cfg_path = path.unwrap_or(dirs::home_dir().unwrap().join(".0L").join("0L.toml"));
+
     let mut toml_buf = "".to_string();
-    let mut file = File::open(&path)?;
+    let mut file = File::open(&cfg_path)?;
     file.read_to_string(&mut toml_buf)?;
 
 
@@ -74,7 +75,7 @@ pub fn parse_toml(path: PathBuf) -> Result<AppCfg, Error> {
 
 /// Get a AppCfg object from toml file
 pub fn fix_missing_fields(path: PathBuf) -> Result<(), Error> {
-    let cfg: AppCfg = parse_toml(path)?;
+    let cfg: AppCfg = parse_toml(Some(path))?;
     cfg.save_file();
     Ok(())
 }

--- a/ol/types/src/fixtures.rs
+++ b/ol/types/src/fixtures.rs
@@ -74,7 +74,7 @@ pub fn get_persona_toml_configs(persona: &str) -> AppCfg {
   .parent()
   .unwrap()
   .join("fixtures/configs").join(format!("{}.toml", persona));
-  parse_toml(buf).expect("could not get fixtures for persona")
+  parse_toml(Some(buf)).expect("could not get fixtures for persona")
 }
 
 

--- a/ol/types/src/lib.rs
+++ b/ol/types/src/lib.rs
@@ -20,4 +20,4 @@ pub mod fullnode_counter;
 pub mod wallet;
 pub mod genesis_proof;
 pub mod fixtures;
-
+pub mod rpc_playlist;

--- a/ol/types/src/rpc_playlist.rs
+++ b/ol/types/src/rpc_playlist.rs
@@ -1,0 +1,44 @@
+//! seed peers for connecting to various networks.
+use anyhow::Error;
+use serde::{Deserialize};
+use url::Url;
+
+#[derive(Deserialize)]
+pub struct FullnodePlaylist {
+    ///
+    pub nodes: Vec<HostInfo>
+}
+
+#[derive(Deserialize)]
+pub struct HostInfo {
+    ///
+    pub note: String,
+    ///
+    pub url: Url,
+}
+
+// try to fetch current fullnodes for mainnet from github
+pub fn get_known_fullnodes(seed_url: Option<Url>) -> Result<Vec<HostInfo>, Error> {
+
+  //TODO: Move this default elsewhere, possibly duplicated with src/components/settings/SetNetworkPlaylist.svelte
+  let url = seed_url.unwrap_or("https://raw.githubusercontent.com/OLSF/carpe/main/seed_peers/fullnode_seed_playlist.json".parse().unwrap());
+
+  Ok(FullnodePlaylist::http_fetch_playlist(url)?.nodes)
+}
+
+impl FullnodePlaylist {
+  // extract the urls
+  pub fn get_urls(&self) -> Vec<Url>{
+    self.nodes.iter()
+    .filter_map(|a| {
+      Some(a.url.to_owned())
+    })
+    .collect()
+  }
+
+  pub fn http_fetch_playlist(url: Url) -> Result<FullnodePlaylist, Error> {
+    let res = reqwest::blocking::get(url)?;
+    let play: FullnodePlaylist = serde_json::from_str(&res.text()?)?;//res.text()?.parse()?;
+    Ok(play)
+  }
+}


### PR DESCRIPTION
- [x] add rpc-playlist option to `on init` so that users can easily update the `upstream-peers` from command line.
- [x] Refactor chain_view.rs which had evil unwraps which are causing panics in `ol start` 