### PR TITLE
[txs] change balance_transfer API for Carpe app

### DIFF
--- a/ol/txs/src/commands/transfer_cmd.rs
+++ b/ol/txs/src/commands/transfer_cmd.rs
@@ -2,7 +2,11 @@
 
 #![allow(clippy::never_loop)]
 
-use crate::{entrypoint, submit_tx::{TxError, maybe_submit, tx_params_wrapper}};
+use crate::{
+    entrypoint,
+    submit_tx::{TxError, maybe_submit, tx_params_wrapper},
+    tx_params::TxParams,
+};
 use abscissa_core::{Command, Options, Runnable};
 
 use diem_json_rpc_types::views::TransactionView;
@@ -29,8 +33,8 @@ impl Runnable for TransferCmd {
               exit(1);
             },
         };
-
-        match balance_transfer(destination, self.coins, entry_args.save_path) {
+        let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
+        match balance_transfer(destination, self.coins, tx_params, entry_args.save_path) {
             Ok(_) => println!("Success: Balance transfer posted: {}", self.destination_account),
             Err(e) => {
               println!("ERROR: execute balance transfer message: {:?}", &e);
@@ -41,9 +45,7 @@ impl Runnable for TransferCmd {
 }
 
 /// create an account by sending coin to it
-pub fn balance_transfer(destination: AccountAddress, coins: u64, save_path: Option<PathBuf>) -> Result<TransactionView, TxError>{
-  let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
-
+pub fn balance_transfer(destination: AccountAddress, coins: u64, tx_params: TxParams, save_path: Option<PathBuf>) -> Result<TransactionView, TxError>{
   // NOTE: coins here do not have the scaling factor. Rescaling is the responsibility of the Move script. See the script in ol_accounts.move for detail.
   let script = transaction_builder::encode_balance_transfer_script_function(
       destination,


### PR DESCRIPTION
## Motivation

The current implementation of balance_transfer makes the app crash when invoked from Carpe app, possibly due to the call to get TxParams inside balance_transfer. So, this PR requires the calling code to directly pass TxParams parameter when invoking balance_transfer

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

You can run the following command
```
cargo xtest --package txs
```

## Related PRs

[[cli] API for getting wallet type](https://github.com/OLSF/carpe/pull/73)