### PR TITLE
Refactor WalletType enum

### DIFF
--- a/ol/genesis-tools/src/recover.rs
+++ b/ol/genesis-tools/src/recover.rs
@@ -38,7 +38,7 @@ pub enum AccountRole {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalletType {
     ///
-    None,
+    Normal,
     ///
     Slow,
     ///


### PR DESCRIPTION
## Motivation

Currently, the default wallet type is named "None", which can be misleading and make Carpe developers have to do additional type-checking steps converting from "None" to "Normal" in order to show wallet type. This PR specifies default wallet type to "Normal" when initialize, clearer and allowing Carpe to show type directly without the needs to convert.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

None

## Related PRs

[[wallet] show wallet type](https://github.com/OLSF/carpe/pull/74)