### PR TITLE
add missing semicolons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,13 +370,13 @@ ifdef TEST
 	@echo NAMESPACE: ${NS}
 	@echo GENESIS: ${V}
 	@if test ! -d ${DATA_PATH}; then \
-		echo Creating Directories \
+		echo Creating Directories; \
 		mkdir ${DATA_PATH}; \
 		mkdir -p ${DATA_PATH}/vdf_proofs/; \
 	fi
 
 	@if test ! -d ${DATA_PATH}/vdf_proofs; then \
-		echo Creating Directories \
+		echo Creating Directories; \
 		mkdir -p ${DATA_PATH}/vdf_proofs/; \
 	fi
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Small bug fix for errors I encountered while working on running a testnet.

## Test Plan
### before:
```
# make dev-register
NAMESPACE: bob
GENESIS: previous
Creating Directories mkdir -p /root/.0L/vdf_proofs/
cp ./ol/fixtures/configs/bob.toml /root/.0L/0L.toml
cp ./ol/fixtures/vdf_proofs/test/bob/proof_0.json /root/.0L/vdf_proofs/proof_0.json
cp: cannot create regular file '/root/.0L/vdf_proofs/proof_0.json': No such file or directory
make: *** [Makefile:378: fix] Error 1
```

### after:
```
# make dev-register
NAMESPACE: carol
GENESIS: previous
Creating Directories
cp ./ol/fixtures/configs/carol.toml /root/.0L/0L.toml                                                                                          
cp ./ol/fixtures/vdf_proofs/test/carol/proof_0.json /root/.0L/vdf_proofs/proof_0.json
cp ./ol/fixtures/autopay/carol.autopay_batch.json /root/.0L/autopay_batch.json
cp ./ol/fixtures/account/carol.account.json /root/.0L/account.json
cp ./ol/devnet/set_layout_test.toml /root/.0L/set_layout.toml
...
```
