### PR TITLE
[txs] use managment costs instead of cheap costs for autopay batch TX

### DIFF
--- a/ol/txs/src/commands/autopay_batch_cmd.rs
+++ b/ol/txs/src/commands/autopay_batch_cmd.rs
@@ -35,7 +35,7 @@ impl Runnable for AutopayBatchCmd {
         // Note: autopay batching needs to have id numbers to each instruction.
         // will not increment automatically, since this can lead to user error.
         let entry_args = entrypoint::get_args();
-        let tx_params = tx_params_wrapper(TxType::Cheap).unwrap();
+        let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
         let cfg = app_config();
 
         // // get highest autopay number

--- a/ol/txs/src/commands/burn_pref_cmd.rs
+++ b/ol/txs/src/commands/burn_pref_cmd.rs
@@ -27,7 +27,7 @@ pub struct BurnPrefCmd {
 impl Runnable for BurnPrefCmd {    
     fn run(&self) {
         let entry_args = entrypoint::get_args();
-        let tx_params = tx_params_wrapper(TxType::Cheap).unwrap();
+        let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
 
         match set_burn_prefs(
           &tx_params,

--- a/ol/txs/src/commands/vouch_cmd.rs
+++ b/ol/txs/src/commands/vouch_cmd.rs
@@ -29,7 +29,7 @@ pub struct VouchCmd {
 impl Runnable for VouchCmd {
     fn run(&self) {
         let _entry_args = entrypoint::get_args();
-        let tx_params = tx_params_wrapper(TxType::Cheap).unwrap();
+        let tx_params = tx_params_wrapper(TxType::Mgmt).unwrap();
 
         let script = if self.address.is_some() {
             if let Some(addr) = &self.address {


### PR DESCRIPTION
## Motivation
Setting autopay via batch file leads to out-of-gas exceptions because cheap transaction cost settings are used instead of management transaction costs