### PR TITLE
Add CLI Option - unlocked balance for slow wallets

### DIFF
--- a/ol/cli/src/commands/query_cmd.rs
+++ b/ol/cli/src/commands/query_cmd.rs
@@ -96,7 +96,7 @@ impl Runnable for QueryCmd {
             display = "BALANCE";
         }
         else if self.unlocked_balance {
-            query_type = QueryType::UnlockedBalance(account);
+            query_type = QueryType::UnlockedBalance{account};
             display = "UNLOCKED BALANCE";
         }
         else if self.blockheight {

--- a/ol/cli/src/commands/query_cmd.rs
+++ b/ol/cli/src/commands/query_cmd.rs
@@ -24,6 +24,9 @@ pub struct QueryCmd {
     #[options(short = "b", help = "balance")]
     balance: bool,
 
+    #[options(short = "u", help = "unlocked balance")]
+    unlocked_balance: bool,
+
     #[options(no_short, help = "blockheight")]
     blockheight: bool,
     
@@ -91,6 +94,10 @@ impl Runnable for QueryCmd {
         if self.balance {
             query_type = QueryType::Balance{account};
             display = "BALANCE";
+        }
+        else if self.unlocked_balance {
+            query_type = QueryType::UnlockedBalance(account);
+            display = "UNLOCKED BALANCE";
         }
         else if self.blockheight {
             query_type = QueryType::BlockHeight;

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -365,16 +365,8 @@ pub fn is_slow_wallet(r: &AnnotatedAccountStateBlob) -> bool {
         slow_struct_name.to_string(),
         "unlocked".to_string(),
     );
-    if let Some(AnnotatedMoveValue::U64(0)) = unlocked {
-        let transferred = find_value_from_state(
-            &r,
-            slow_module_name.to_string(),
-            slow_struct_name.to_string(),
-            "transferred".to_string(),
-        );
-        if let Some(AnnotatedMoveValue::U64(0)) = transferred {
-            return true;
-        }
+    if !unlocked.is_none() {
+        return true;
     }
     false
 }
@@ -484,39 +476,9 @@ fn test_find_annotated_move_value() {
 fn test_is_slow_wallet_should_return_true() {
     let value = vec![
         (Identifier::new("unlocked").unwrap(), AnnotatedMoveValue::U64(0)),
-        (Identifier::new("transferred").unwrap(), AnnotatedMoveValue::U64(0))
     ];
     let s = test_fixture_wallet_type("DiemAccount", "SlowWallet", value);
     assert_eq!(true, is_slow_wallet(&s), "{}", s.to_string());
-}
-
-#[test]
-fn test_is_slow_wallet_should_return_false_with_wrong_unlocked() {
-    let value = vec![
-        (Identifier::new("unlocked").unwrap(), AnnotatedMoveValue::U64(1)),
-        (Identifier::new("transferred").unwrap(), AnnotatedMoveValue::U64(0))
-    ];
-    let s = test_fixture_wallet_type("DiemAccount", "SlowWallet", value);
-    assert_eq!(false, is_slow_wallet(&s), "{}", s.to_string());
-}
-
-#[test]
-fn test_is_slow_wallet_should_return_false_with_wrong_transferred() {
-    let value = vec![
-        (Identifier::new("unlocked").unwrap(), AnnotatedMoveValue::U64(0)),
-        (Identifier::new("transferred").unwrap(), AnnotatedMoveValue::U64(1))
-    ];
-    let s = test_fixture_wallet_type("DiemAccount", "SlowWallet", value);
-    assert_eq!(false, is_slow_wallet(&s), "{}", s.to_string());
-}
-
-#[test]
-fn test_is_slow_wallet_should_return_false_if_missing_transferred() {
-    let value = vec![
-        (Identifier::new("unlocked").unwrap(), AnnotatedMoveValue::U64(0))
-    ];
-    let s = test_fixture_wallet_type("DiemAccount", "SlowWallet", value);
-    assert_eq!(false, is_slow_wallet(&s), "{}", s.to_string());
 }
 
 #[test]

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -27,6 +27,11 @@ pub enum QueryType {
         /// account to query txs of
         account: AccountAddress,
     },
+    /// Unlocked Account balance
+    UnlockedBalance {
+        /// account to query txs of
+        account: AccountAddress,
+    },
     /// Epoch and waypoint
     Epoch,
     /// Network block height
@@ -114,6 +119,21 @@ impl Node {
                     }
                     Ok(None) => format!("No account {} found on chain, account", account),
                     Err(e) => format!("Chain query error: {:?}", e),
+                }
+            }
+            UnlockedBalance { account } => {
+                // account
+                match self.get_annotate_account_blob(account) {
+                    Ok((Some(r), _)) => {
+                        if !is_slow_wallet(&r) {
+                            format!("Error, account is not a slow wallet")
+                        }else{
+                            let value = find_value_from_state(&r, "DiemAccount".to_string(), "SlowWallet".to_string(), "unlocked".to_string());
+                            format!("{:#?}", value)
+                        }
+                    }
+                    Err(e) => format!("Error retrieving unlocked balance. Message: {:#?}", e),
+                    _ => format!("Error, cannot find account state for {:#?}", account),
                 }
             }
             BlockHeight => self.refresh_chain_info()?.0.height.to_string(),

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -129,7 +129,7 @@ impl Node {
                             format!("Error, account is not a slow wallet")
                         }else{
                             let value = find_value_from_state(&r, "DiemAccount".to_string(), "SlowWallet".to_string(), "unlocked".to_string());
-                            format!("{:#?}", value)
+                            value.unwrap().to_string()
                         }
                     }
                     Err(e) => format!("Error retrieving unlocked balance. Message: {:#?}", e),


### PR DESCRIPTION
## Motivation

Give slow wallets owners the ability to see their unlocked balance without sifting through account resources. 

## Test Plan

- `cargo xtest --package ol`
- Built locally and tested

-  Outcome account set as slow wallet
![Screen Shot 2022-05-12 at 2 31 46 PM](https://user-images.githubusercontent.com/97761083/168171782-96e4a36f-33f8-4da2-b9ae-b18f0a41f402.png)

- Outcome with an account that is not set as slow wallet
![Screen Shot 2022-05-12 at 2 33 53 PM](https://user-images.githubusercontent.com/97761083/168171950-19fccd7b-d486-4d2d-94fd-ba6d83e6b993.png)



## Related PRs

This PR is dependent on #1108 being merged
