### PR TITLE
[diem-node] Patch Move error type handling by VM because of 0L error format changes

### DIFF
--- a/language/diem-vm/src/errors.rs
+++ b/language/diem-vm/src/errors.rs
@@ -60,48 +60,40 @@ pub fn convert_prologue_error(
             VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
         }
         VMStatus::MoveAbort(location, code) => {
-            let new_major_status = match error_split(code) {
-                (INVALID_STATE, EACCOUNT_FROZEN) => StatusCode::SENDING_ACCOUNT_FROZEN,
+            let new_major_status = match code {
+                (EACCOUNT_FROZEN) => StatusCode::SENDING_ACCOUNT_FROZEN,
                 // Invalid authentication key
-                (INVALID_ARGUMENT, EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
+                (EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
                 // Sequence number too old
-                (INVALID_ARGUMENT, ESEQUENCE_NUMBER_TOO_OLD) => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
+                (ESEQUENCE_NUMBER_TOO_OLD) => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
                 // Sequence number too new
-                (INVALID_ARGUMENT, ESEQUENCE_NUMBER_TOO_NEW) => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
+                (ESEQUENCE_NUMBER_TOO_NEW) => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
                 // Sequence number too new
-                (INVALID_ARGUMENT, EACCOUNT_DOES_NOT_EXIST) => {
+                (EACCOUNT_DOES_NOT_EXIST) => {
                     StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST
                 }
                 // Can't pay for transaction gas deposit/fee
-                (INVALID_ARGUMENT, ECANT_PAY_GAS_DEPOSIT) => {
+                (ECANT_PAY_GAS_DEPOSIT) => {
                     StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE
                 }
-                (INVALID_ARGUMENT, ETRANSACTION_EXPIRED) => StatusCode::TRANSACTION_EXPIRED,
-                (INVALID_ARGUMENT, EBAD_CHAIN_ID) => StatusCode::BAD_CHAIN_ID,
-                (INVALID_STATE, ESCRIPT_NOT_ALLOWED) => StatusCode::UNKNOWN_SCRIPT,
-                (INVALID_STATE, EMODULE_NOT_ALLOWED) => StatusCode::INVALID_MODULE_PUBLISHER,
-                (INVALID_ARGUMENT, EINVALID_WRITESET_SENDER) => StatusCode::REJECTED_WRITE_SET,
+                (ETRANSACTION_EXPIRED) => StatusCode::TRANSACTION_EXPIRED,
+                (EBAD_CHAIN_ID) => StatusCode::BAD_CHAIN_ID,
+                (ESCRIPT_NOT_ALLOWED) => StatusCode::UNKNOWN_SCRIPT,
+                (EMODULE_NOT_ALLOWED) => StatusCode::INVALID_MODULE_PUBLISHER,
+                (EINVALID_WRITESET_SENDER) => StatusCode::REJECTED_WRITE_SET,
                 // Sequence number will overflow
-                (LIMIT_EXCEEDED, ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
+                (ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
                 // The gas currency is not registered as a TransactionFee currency
-                (INVALID_ARGUMENT, EBAD_TRANSACTION_FEE_CURRENCY) => {
+                (EBAD_TRANSACTION_FEE_CURRENCY) => {
                     StatusCode::BAD_TRANSACTION_FEE_CURRENCY
                 }
-                (INVALID_ARGUMENT, ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
+                (ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
                     StatusCode::SECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH
                 }
-                (category, reason) => {
-                    log_context.alert();
-                    error!(
-                        *log_context,
-                        "[diem_vm] Unexpected prologue Move abort: {:?}::{:?} (Category: {:?} Reason: {:?})",
-                        location, code, category, reason,
-                    );
-
-                    // TODO: Improve error reporting for devs https://github.com/OLSF/libra/issues/760
-                    return Err(VMStatus::Error(
-                        StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION,
-                    ));
+                (code) => {
+                    // 0L: don't throw an error here, as 0L may have added error codes. If you see this line, this file should be updated to include the new error
+                    eprintln!("[diem_vm] Unexpected prologue Move abort: Location: {:?} Code: {:?}", location, code,);
+                    StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
             };
             VMStatus::Error(new_major_status)

--- a/language/diem-vm/src/errors.rs
+++ b/language/diem-vm/src/errors.rs
@@ -26,9 +26,10 @@ pub const ESEQUENCE_NUMBER_TOO_BIG: u64 = 1011;
 pub const EBAD_TRANSACTION_FEE_CURRENCY: u64 = 1012;
 pub const ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH: u64 = 1013;
 
-const INVALID_STATE: u8 = 1;
-const INVALID_ARGUMENT: u8 = 7;
-const LIMIT_EXCEEDED: u8 = 8;
+// Deprecated in 0L
+//const INVALID_STATE: u8 = 1;
+//const INVALID_ARGUMENT: u8 = 7;
+//const LIMIT_EXCEEDED: u8 = 8;
 
 fn error_split(code: u64) -> (u8, u64) {
     let category = code as u8;
@@ -61,36 +62,36 @@ pub fn convert_prologue_error(
         }
         VMStatus::MoveAbort(location, code) => {
             let new_major_status = match code {
-                (EACCOUNT_FROZEN) => StatusCode::SENDING_ACCOUNT_FROZEN,
+                EACCOUNT_FROZEN => StatusCode::SENDING_ACCOUNT_FROZEN,
                 // Invalid authentication key
-                (EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
+                EBAD_ACCOUNT_AUTHENTICATION_KEY => StatusCode::INVALID_AUTH_KEY,
                 // Sequence number too old
-                (ESEQUENCE_NUMBER_TOO_OLD) => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
+                ESEQUENCE_NUMBER_TOO_OLD => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
                 // Sequence number too new
-                (ESEQUENCE_NUMBER_TOO_NEW) => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
+                ESEQUENCE_NUMBER_TOO_NEW => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
                 // Sequence number too new
-                (EACCOUNT_DOES_NOT_EXIST) => {
+                EACCOUNT_DOES_NOT_EXIST => {
                     StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST
                 }
                 // Can't pay for transaction gas deposit/fee
-                (ECANT_PAY_GAS_DEPOSIT) => {
+                ECANT_PAY_GAS_DEPOSIT => {
                     StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE
                 }
-                (ETRANSACTION_EXPIRED) => StatusCode::TRANSACTION_EXPIRED,
-                (EBAD_CHAIN_ID) => StatusCode::BAD_CHAIN_ID,
-                (ESCRIPT_NOT_ALLOWED) => StatusCode::UNKNOWN_SCRIPT,
-                (EMODULE_NOT_ALLOWED) => StatusCode::INVALID_MODULE_PUBLISHER,
-                (EINVALID_WRITESET_SENDER) => StatusCode::REJECTED_WRITE_SET,
+                ETRANSACTION_EXPIRED => StatusCode::TRANSACTION_EXPIRED,
+                EBAD_CHAIN_ID => StatusCode::BAD_CHAIN_ID,
+                ESCRIPT_NOT_ALLOWED => StatusCode::UNKNOWN_SCRIPT,
+                EMODULE_NOT_ALLOWED => StatusCode::INVALID_MODULE_PUBLISHER,
+                EINVALID_WRITESET_SENDER => StatusCode::REJECTED_WRITE_SET,
                 // Sequence number will overflow
-                (ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
+                ESEQUENCE_NUMBER_TOO_BIG => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
                 // The gas currency is not registered as a TransactionFee currency
-                (EBAD_TRANSACTION_FEE_CURRENCY) => {
+                EBAD_TRANSACTION_FEE_CURRENCY => {
                     StatusCode::BAD_TRANSACTION_FEE_CURRENCY
                 }
-                (ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
+                ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH => {
                     StatusCode::SECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH
                 }
-                (code) => {
+                _ => {
                     // 0L: don't throw an error here, as 0L may have added error codes. If you see this line, this file should be updated to include the new error
                     eprintln!("[diem_vm] Unexpected prologue Move abort: Location: {:?} Code: {:?}", location, code,);
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
@@ -133,16 +134,11 @@ pub fn convert_epilogue_error(
             VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
         }
 
-        VMStatus::MoveAbort(location, code) => match error_split(code) {
-            (LIMIT_EXCEEDED, ECANT_PAY_GAS_DEPOSIT) => VMStatus::MoveAbort(location, code),
-            (category, reason) => {
-                log_context.alert();
-                error!(
-                    *log_context,
-                    "[diem_vm] Unexpected success epilogue Move abort: {:?}::{:?} (Category: {:?} Reason: {:?})",
-                    location, code, category, reason,
-                );
-                VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
+        VMStatus::MoveAbort(location, code) => match code {
+            ECANT_PAY_GAS_DEPOSIT => VMStatus::MoveAbort(location, code),
+            _ => {
+                eprintln!("[diem_vm] Unexpected epilogue Move abort: Location: {:?} Code: {:?}", location, code,);
+                VMStatus::MoveAbort(location, code)
             }
         },
 


### PR DESCRIPTION
This is in response to the issues faced by validators. I believe this is an important source of problems.

Recently, when my node fell out of the set, the last non-trivial error it had was: 
`ERROR language/diem-vm/src/errors.rs:95 [diem_vm] Unexpected prologue Move abort: 00000000000000000000000000000001::DiemAccount::1004 (Category: 236 Reason: 3) {"base_version":40969506,"name":"validation","txn_id":0}`

This led me to try find this error, which is PROLOGUE_EACCOUNT_DNE in DiemAccount. Notably, that error code is 1004, not 3, as would be suggested by the "Reason" given in the error. Additionally,  checking Errors.move tells be that "Category" 236 does not exist. 

erros.rs in the diem-vm handles errors assuming that they are in the Category, Reason format. However, 0L updated Errors.move to only give the Reason, to make our error output more straightforward, see [here](https://github.com/OLSF/libra/blob/837785dcfdaac2c6143a47775c6e5799e64cbcce/language/move-stdlib/modules/Errors.move#L20).  So, the diem-vm error handler is seeing an unexpected error, and so it is unable to match it (this matching is specific to the prologue and epilogue, as there are relatively few possible errors there). Because it can't match the error, it is throwing an error in the Rust code, despite the benign underlying issue (an account not existing but sending a transaction, in this case). 

I don't know what exactly the downstream effects of this error would be, or if it is the cause of the network issues, but there are a few things that lead me to think it might be the cause. 

- This would account for the intermittent nature of the failures. Only erroneous transactions would cause trigger this error, and so they should be rare and somewhat random. 
- The error would be more likely to be caused when more users are sending transactions/are online, which is what has been experienced
- Nodes should not propagate erroneous transactions, which would explain why only some validators are failing, again, seemingly at random 

I am currently running this on my node, and it appears stable thus far (but it's only been 20 minutes)