### PR TITLE
[move] [Fast Track Proposal] Turn down the heat on Cost To Exist

### DIFF
--- a/language/diem-framework/modules/0L/Burn.move
+++ b/language/diem-framework/modules/0L/Burn.move
@@ -96,7 +96,7 @@ module Burn {
       }
     } else {
 
-      send(vm, payer, value);
+      burn(vm, payer, value);
     };
   }
 

--- a/language/diem-framework/modules/0L/EpochBoundary.move
+++ b/language/diem-framework/modules/0L/EpochBoundary.move
@@ -275,7 +275,9 @@ module EpochBoundary {
         let vals_to_burn = if (
           !Testnet::is_testnet() &&
           !StagingNet::is_staging_net() &&
-          DiemConfig::get_current_epoch() > 185
+          DiemConfig::get_current_epoch() > 290 && // bump up to epoch 290 so people can discuss.
+          // only implement this burn at a steady state with 90/100 validator positions full. Will make the burn amount much smaller over time.
+          Vector::length<address>(proposed_set) > 90
         ) {
           &ValidatorUniverse::get_eligible_validators(vm)
         } else {


### PR DESCRIPTION
Turn Down Heat On Cost To Exist

Give it to me straight:
Approximately ten days after deployment, we were alerted that the Cost To Exist isn't doing what we expect.

This proposal stops the burn on inactive validators for 90 days, while also adding limits on burn amounts and triggers such that it would take years to deplete an abandoned account.

This will let validators hurt by the change a) have their balances catch up, b) allow network to return to steady state and c) evaluate the proposal and plan accordingly.

Background:
During the April Halt, many vocal members of the network felt there needed to be a greater cost to inactive validators for the privileged position they have. Cost-to-exist was the favored mechanism.

In blockchain there is always a cost to inactivity.

Usually BFT blockchains, in using PoS,  there are costs to being inactive, sometimes explicitly like slashing for liveness. But the biggest penalty to inactive accounts is invisible, it's done through dilution/inflation. PoS networks usually define "active" participants as the validator pools (both operator and delegates), and they receive new issuance of coin. Due to this, all passive account holders, apps, end users, foundations, on-chain treasuries, and inactive validators get slowly slashed by inflation.

This may be desirable in certain cases. [0L's economic principles](https://0l.network/2021/11/16/future-proofing-the-economics-of-blockchains-pts-1-2/) argues that inflation is not always honest; in the worst case it is deception. Neither is it practical for all cases. Instead it's simpler and more honest to charge the cost directly to inactive accounts, rather than sneaking-in the slash on the accounts. Despite all this, inflation lives on as a crude policy tool since it is not easily detectable.

More practically 0L is not a Proof of Stake chain. We do not have delegation. So if the goal is to isolate inactive accounts and inflate the rest, there's no credible technical solution to do this. 

Cost to Exist is intended to be transparent and clear.  It's also intended to be very long term. It should operate at multi-year time spans, and principally affect "abandoned" validators. 

There were a number of problems with the rollout.

What's the problem:
Cost To Exist was implemented without enough controls. Now there's a corner case in Cost To Exist, which is creating more burn than is needed for the network to be healthy. It comes off as aggressive and surprising. That's not the intention and not in the spirit of the community.

One problem was a flawed assumption: that after restoring the network from the April Halt, the validator set would quickly be at 80+ validators. Not enough controls were made for this case not materializing.

Currently the network is stuck without being able to return to the previous steady-state of 80+ validators on the network. There's a separate pull request [Jail Refactor](https://github.com/OLSF/libra/pull/1118) which addresses this. Since we haven’t reached scale, the Cost To Exist is burning greater balances than expected due to the implementation.

Plus the time period for proposal activation was too short. The period of abeyance for the proposal to go into effect (at epoch 185), was too short given the multiple constraints in communicating (given all events in the industry of late). There are active contributors only now learning about the proposal. If it feels like a rug-pull to anyone then we've failed in communicating and getting consensus.

Last, It is not critical that this proposal be activated immediately for it to have its desired effect of coaxing inactive validators to participate, or gradually transfer coins out of their validator account.

This proposal turns down the heat, and proposes a more constrained implementation.

Changes in this PR:

1. Only implement at steady state. The Cost To Exist, will only be implemented at steady state: when 90+ validators out of 100 successfully operating in an epoch.

2. The cost is reduced. By placing the threshold at 90 validators the cost is exponentially smaller.  The cost is always 50% of the reward in the epoch. As such the maximum cost would be 2,000 GAS per epoch, and goes down to 0 if there are 100 validators on the network.

3. Fix the fail-over behavior. There are many accounts that don't have BurnPreference set. And the default was to send to community index. This was a faulty implementation and also a bad assumption. This change assumes validators unaware of the change (and who have not specified preferences) will have a pure burn, instead of a recycle to community wallet index.

4. Escape Hatch. There will be abundant time to evaluate and plan. This proposal can be rejected with an upgrade before epoch 290. Ninety days will be sufficient time for comment, and a broad consensus should be expected at that point.