### PR TITLE
[move] reduce thresholds on validators

### DIFF
--- a/language/diem-framework/modules/0L/Globals.move
+++ b/language/diem-framework/modules/0L/Globals.move
@@ -118,7 +118,7 @@ module Globals {
           epoch_slow_wallet_unlock: 10,
           min_blocks_per_epoch: 0,
           vouch_threshold: 0,
-          signing_threshold_pct: 0,
+          signing_threshold_pct: 3,
         }
       };
 
@@ -134,7 +134,7 @@ module Globals {
           epoch_slow_wallet_unlock: 10000000,
           min_blocks_per_epoch: 1000,
           vouch_threshold: 0,
-          signing_threshold_pct: 0,
+          signing_threshold_pct: 3,
         }
       } else {
         return GlobalConstants {

--- a/language/diem-framework/modules/0L/Globals.move
+++ b/language/diem-framework/modules/0L/Globals.move
@@ -89,6 +89,10 @@ module Globals {
       get_constants().min_blocks_per_epoch
     }
 
+    /// Get the mining threshold 
+    public fun get_vouch_threshold(): u64 {
+      get_constants().vouch_threshold
+    }
 
 
     /// Get the constants for the current network 
@@ -107,6 +111,7 @@ module Globals {
           epoch_mining_thres_upper: 1000, // upper bound unlimited
           epoch_slow_wallet_unlock: 10,
           min_blocks_per_epoch: 0,
+          vouch_threshold: 0,
         }
       };
 
@@ -121,6 +126,7 @@ module Globals {
           epoch_mining_thres_upper: 72, // upper bound enforced at 20 mins per proof.
           epoch_slow_wallet_unlock: 10000000,
           min_blocks_per_epoch: 1000,
+          vouch_threshold: 0,
         }
       } else {
         return GlobalConstants {
@@ -138,6 +144,7 @@ module Globals {
           epoch_mining_thres_upper: 72, // upper bound enforced at 20 mins per proof.
           epoch_slow_wallet_unlock: 1000 * COIN_SCALING_FACTOR, // approx 10 years for largest accounts in genesis.
           min_blocks_per_epoch: 10000,
+          vouch_threshold: 2, // Production is 2 vouchers per validator
         }
       }
     }

--- a/language/diem-framework/modules/0L/Globals.move
+++ b/language/diem-framework/modules/0L/Globals.move
@@ -34,6 +34,8 @@ module Globals {
       epoch_mining_thres_upper: u64,
       epoch_slow_wallet_unlock: u64,
       min_blocks_per_epoch: u64,
+      vouch_threshold: u64,
+      signing_threshold_pct: u64,
     }
 
     const COIN_SCALING_FACTOR: u64 = 1000000;
@@ -89,11 +91,15 @@ module Globals {
       get_constants().min_blocks_per_epoch
     }
 
-    /// Get the mining threshold 
+    /// Get the threshold for unrelated vouchers per validator
     public fun get_vouch_threshold(): u64 {
       get_constants().vouch_threshold
     }
 
+    /// Get the threshold of number of signed blocks in an epoch per validator
+    public fun get_signing_threshold(): u64 {
+      get_constants().signing_threshold_pct
+    }
 
     /// Get the constants for the current network 
     fun get_constants(): GlobalConstants {
@@ -112,6 +118,7 @@ module Globals {
           epoch_slow_wallet_unlock: 10,
           min_blocks_per_epoch: 0,
           vouch_threshold: 0,
+          signing_threshold_pct: 0,
         }
       };
 
@@ -127,6 +134,7 @@ module Globals {
           epoch_slow_wallet_unlock: 10000000,
           min_blocks_per_epoch: 1000,
           vouch_threshold: 0,
+          signing_threshold_pct: 0,
         }
       } else {
         return GlobalConstants {
@@ -145,6 +153,7 @@ module Globals {
           epoch_slow_wallet_unlock: 1000 * COIN_SCALING_FACTOR, // approx 10 years for largest accounts in genesis.
           min_blocks_per_epoch: 10000,
           vouch_threshold: 2, // Production is 2 vouchers per validator
+          signing_threshold_pct: 3,
         }
       }
     }

--- a/language/diem-framework/modules/0L/Stats.move
+++ b/language/diem-framework/modules/0L/Stats.move
@@ -11,7 +11,8 @@ module Stats{
   use 0x1::FixedPoint32;
   use 0x1::Signer;
   use 0x1::Testnet;
-  use 0x1::Vector;    
+  use 0x1::Vector;
+  use 0x1::Globals;
 
   // TODO: yes we know this slows down block production. In "make it fast" mode this will be moved to Rust, in the vm execution block prologue. TBD.
   
@@ -113,7 +114,10 @@ module Stats{
     assert(sender == CoreAddresses::DIEM_ROOT_ADDRESS(), Errors::requires_role(190006));
     let range = height_end-height_start;
     // TODO: Change to 5 percent
-    let threshold_signing = FixedPoint32::multiply_u64(range, FixedPoint32::create_from_rational(5, 100));
+    let threshold_signing = FixedPoint32::multiply_u64(
+      range, 
+      FixedPoint32::create_from_rational(Globals::get_signing_threshold(), 100)
+    );
     if (node_current_votes(vm, node_addr) >  threshold_signing) { return true };
     return false
   }

--- a/language/diem-framework/modules/0L/Vouch.move
+++ b/language/diem-framework/modules/0L/Vouch.move
@@ -11,9 +11,8 @@ address 0x1 {
     use 0x1::ValidatorUniverse;
     use 0x1::DiemSystem;
     use 0x1::Ancestry;
-    use 0x1::Testnet;
-    use 0x1::StagingNet;
     use 0x1::CoreAddresses;
+    use 0x1::Globals;
 
     // triggered once per epoch
     struct Vouch has key {
@@ -145,15 +144,11 @@ address 0x1 {
     }
 
     public fun unrelated_buddies_above_thresh(val: address): bool acquires Vouch{
-      if (Testnet::is_testnet() || StagingNet::is_staging_net()) {
-        return true
-      };
-
       if (!exists<Vouch>(val)) return false;
 
       let len = Vector::length(&unrelated_buddies(val));
 
-      (len >= 4) // TODO: move to Globals
+      (len >= Globals::get_vouch_threshold())
     }
   }
 }


### PR DESCRIPTION
The validator set has struggled to grow because of some technical issues with state-sync and backup and restore. Though the thresholds, which exist to create a higher quality group of validators, are causing some confusion on debugging.

These thresholds should increase over time, as the tooling becomes more straightforward.
This PR proposes that the Vouch threshold be reduced from 4 to 2 vouches for validator, and the epoch block signing threshold be reduced from 5% to 3%.

These thresholds should increase again once a certain metric is hit in the network, e.g. 80+ validators successfully performing.
