### PR TITLE
[node] Don't panic on failure to initialize safety rules.

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -302,9 +302,14 @@ impl EpochManager {
 
         let mut safety_rules =
             MetricsSafetyRules::new(self.safety_rules_manager.client(), self.storage.clone());
+        //////// 0L ////////
+        // Don't panic on initialize. We may be a validator trying to sync from a starting point.
+        // however this error if not solved, will cause a problem on the next epoch.
         if let Err(error) = safety_rules.perform_initialize() {
-            panic!(
-                "Unable to initialize safety rules, epoch: {}, error: {}", epoch, error
+            error!(
+                "Unable to initialize safety rules. YOUR VALIDATOR WILL NOT BE ABLE TO SIGN BLOCKS but it will be able to sync. This is likely a problem with the restore point in your DB.",
+                epoch = epoch,
+                error = error,
             );
         }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -307,9 +307,9 @@ impl EpochManager {
         // however this error if not solved, will cause a problem on the next epoch.
         if let Err(error) = safety_rules.perform_initialize() {
             error!(
-                "Unable to initialize safety rules. YOUR VALIDATOR WILL NOT BE ABLE TO SIGN BLOCKS but it will be able to sync. This is likely a problem with the restore point in your DB.",
                 epoch = epoch,
                 error = error,
+                "Unable to initialize safety rules. YOUR VALIDATOR WILL NOT BE ABLE TO SIGN BLOCKS but it will be able to sync. This is likely a problem with the restore point in your DB.",
             );
         }
 

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -33,8 +33,9 @@ impl MetricsSafetyRules {
             .storage
             .retrieve_epoch_change_proof(sr_waypoint.version())
             .map_err(|e| {
+              //////// 0L ////////
                 Error::InternalError(format!(
-                    "Unable to retrieve epoch change proof from storage for Waypoint. State for version {} not found. Error:{}",
+                    "Unable to retrieve epoch change proof from storage for Waypoint. The node will continue to sync, but the validator will not be able to sign transactions. State for version {} not found. Error:{}",
                     &sr_waypoint.version(),
                     e
                 ))


### PR DESCRIPTION
We remove the panic!() which would prevent the node from starting in validator mode if the safety rules cannot be bootstrapped.

This is desirable because sometimes the validator needs to sync from a cold start, but the restore may not be perfect.
The definitive solution is in providing node operators with a restore point which does not fail.

The operator needs to be aware that doing this will cause an issue if the backup/restore artifacts have incomplete state. The operator will now see an Error in the logs, but will not panic.

To be clear: THE VALIDATOR WILL NOT BE ABLE TO SIGN BLOCKS if the safety riles cannot be initialized, but this change will allow it to sync.