### PR TITLE
V6 shuffle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8628,6 +8628,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-unit-test",
+ "ol-keys",
  "once_cell",
  "rand 0.8.4",
  "reqwest 0.11.10",

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -54,6 +54,9 @@ serde_yaml = "0.8.17"
 smoke-test = { path = "../../testsuite/smoke-test" }
 transaction-builder-generator = { path = "../../diem-move/transaction-builder-generator" }
 
+######### 0L ######## 
+ol-keys = { path = "../../ol/keys"}
+
 [[bin]]
 name = "shuffle"
 path = "src/main.rs"

--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -118,7 +118,9 @@ fn archive_current_files(network_home: &NetworkHome) -> Result<()> {
     let time = duration_since_epoch();
     let archive_dir = network_home.create_archive_dir(time)?;
     network_home.archive_old_key_for(LATEST_USERNAME, &archive_dir)?;
-    network_home.archive_old_address_for(LATEST_USERNAME, &archive_dir)
+    network_home.archive_old_address_for(LATEST_USERNAME, &archive_dir)?;
+    println!("Archived old keys. Manually delete these files if they contain PRODUCTION KEYS {}", archive_dir.display());
+    Ok(())
 }
 
 fn generate_new_account(network_home: &NetworkHome) -> Result<LocalAccount> {
@@ -151,7 +153,6 @@ fn save_private_key(network_home: &NetworkHome) -> Result<LocalAccount> {
     // save the key
     network_home.save_key_from_prompt(&acc, &test_key)?;
 
-    // network_home.generate_testkey_address_file(&test_key.public_key())?;
     Ok(LocalAccount::new(
         acc,
         test_key,

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -211,6 +211,7 @@ impl NetworkHome {
       let mut file = File::create(&file_path)?;
       file.write_all(username.as_bytes())?;
       println!("Keys saved to {}", file_path.parent().unwrap().to_str().unwrap());
+      println!("To delete all keys check all paths in .shuffle/networks, since this tool may backup the keys.");
       Ok(())
     }
     //////// end 0L ////////

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -5,8 +5,9 @@ use crate::context::UserContext;
 use anyhow::{anyhow, Result};
 use diem_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use diem_sdk::client::AccountAddress;
-use diem_types::transaction::authenticator::AuthenticationKey;
+use diem_types::{transaction::authenticator::AuthenticationKey, chain_id::NamedChain};
 use directories::BaseDirs;
+use generate_key::save_key;
 use move_package::{
     compilation::compiled_package::CompiledPackage,
     source_package::{layout::SourcePackageLayout, manifest_parser},
@@ -201,6 +202,19 @@ impl NetworkHome {
         ))
     }
 
+    //////// 0L ///////
+    pub fn save_key_from_prompt(&self, acc: &AccountAddress,  key: &Ed25519PrivateKey) -> Result<()>{
+      let username = acc.to_string();
+      save_key(key.to_owned(), self.key_path_for(LATEST_USERNAME).as_path());
+      // save address file
+      let file_path = self.address_path_for(&LATEST_USERNAME);
+      let mut file = File::create(&file_path)?;
+      file.write_all(username.as_bytes())?;
+      println!("Keys saved to {}", file_path.parent().unwrap().to_str().unwrap());
+      Ok(())
+    }
+    //////// end 0L ////////
+
     pub fn generate_testkey_address_file(&self, public_key: &Ed25519PublicKey) -> Result<()> {
         let address = AuthenticationKey::ed25519(public_key).derived_address();
         let address_filepath = self.address_path_for(TEST_USERNAME);
@@ -372,6 +386,7 @@ pub struct Network {
     json_rpc_url: Url,
     dev_api_url: Url,
     faucet_url: Option<Url>,
+    chain_id: Option<NamedChain> //////// 0L ////////
 }
 
 impl Network {
@@ -380,12 +395,14 @@ impl Network {
         json_rpc_url: Url,
         dev_api_url: Url,
         faucet_url: Option<Url>,
+        chain_id: Option<NamedChain>, //////// 0L ////////
     ) -> Network {
         Network {
             name,
             json_rpc_url,
             dev_api_url,
             faucet_url,
+            chain_id, //////// 0L ////////
         }
     }
 
@@ -411,6 +428,10 @@ impl Network {
             None => Err(anyhow!("This network doesn't have a faucet url")),
         }
     }
+
+    pub fn get_chain_name(&self) -> NamedChain {
+      self.chain_id.unwrap_or(NamedChain::TESTING)
+    }
 }
 
 impl Default for Network {
@@ -420,6 +441,7 @@ impl Default for Network {
             Url::from_str("http://127.0.0.1:8080").unwrap(),
             Url::from_str("http://127.0.0.1:8080").unwrap(),
             None,
+            Some(NamedChain::TESTING), //////// 0L ////////
         )
     }
 }

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -45,7 +45,7 @@ pub async fn run_e2e_tests(
     // happen once, and the second redundant build would be skipped. At least
     // it's cached atm.
     shared::codegen_typescript_libraries(project_path, &account1.address())?;
-    deploy::deploy(&client, &mut account1, project_path).await?;
+    deploy::deploy(&client, &mut account1, project_path, network.get_chain_name()).await?;
 
     let tmp_dir = TempDir::new()?;
     let key1_path = tmp_dir.path().join("private1.key");

--- a/shuffle/move/examples/main/generated/diemStdlib/mod.ts
+++ b/shuffle/move/examples/main/generated/diemStdlib/mod.ts
@@ -129,7 +129,7 @@ export class Stdlib {
     serializer.serializeBytes(content_uri);
     const content_uri_serialized: bytes = serializer.getBytes();
     const args: Seq<bytes> = [content_uri_serialized];
-    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[104], [160], [48], [213], [182], [75], [129], [10], [39], [144], [118], [101], [228], [198], [118], [196]]), new DiemTypes.Identifier("TestNFT"));
+    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[122], [193], [190], [132], [229], [60], [172], [191], [134], [251], [188], [45], [228], [177], [151], [201]]), new DiemTypes.Identifier("TestNFT"));
     const function_name: DiemTypes.Identifier = new DiemTypes.Identifier("create_nft");
     const script = new DiemTypes.ScriptFunction(module_id, function_name, tyArgs, args);
     return new DiemTypes.TransactionPayloadVariantScriptFunction(script);
@@ -141,7 +141,7 @@ export class Stdlib {
   static encodeInitializeNftCollectionScriptFunction(nft_type: DiemTypes.TypeTag): DiemTypes.TransactionPayload {
     const tyArgs: Seq<DiemTypes.TypeTag> = [nft_type];
     const args: Seq<bytes> = [];
-    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[104], [160], [48], [213], [182], [75], [129], [10], [39], [144], [118], [101], [228], [198], [118], [196]]), new DiemTypes.Identifier("NFTStandard"));
+    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[122], [193], [190], [132], [229], [60], [172], [191], [134], [251], [188], [45], [228], [177], [151], [201]]), new DiemTypes.Identifier("NFTStandard"));
     const function_name: DiemTypes.Identifier = new DiemTypes.Identifier("initialize_nft_collection");
     const script = new DiemTypes.ScriptFunction(module_id, function_name, tyArgs, args);
     return new DiemTypes.TransactionPayloadVariantScriptFunction(script);
@@ -156,7 +156,7 @@ export class Stdlib {
     serializer.serializeBytes(message_bytes);
     const message_bytes_serialized: bytes = serializer.getBytes();
     const args: Seq<bytes> = [message_bytes_serialized];
-    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[104], [160], [48], [213], [182], [75], [129], [10], [39], [144], [118], [101], [228], [198], [118], [196]]), new DiemTypes.Identifier("Message"));
+    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[122], [193], [190], [132], [229], [60], [172], [191], [134], [251], [188], [45], [228], [177], [151], [201]]), new DiemTypes.Identifier("Message"));
     const function_name: DiemTypes.Identifier = new DiemTypes.Identifier("set_message");
     const script = new DiemTypes.ScriptFunction(module_id, function_name, tyArgs, args);
     return new DiemTypes.TransactionPayloadVariantScriptFunction(script);
@@ -178,7 +178,7 @@ export class Stdlib {
     serializer.serializeU64(creation_num);
     const creation_num_serialized: bytes = serializer.getBytes();
     const args: Seq<bytes> = [to_serialized, creator_serialized, creation_num_serialized];
-    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[104], [160], [48], [213], [182], [75], [129], [10], [39], [144], [118], [101], [228], [198], [118], [196]]), new DiemTypes.Identifier("NFTStandard"));
+    const module_id: DiemTypes.ModuleId = new DiemTypes.ModuleId(new DiemTypes.AccountAddress([[122], [193], [190], [132], [229], [60], [172], [191], [134], [251], [188], [45], [228], [177], [151], [201]]), new DiemTypes.Identifier("NFTStandard"));
     const function_name: DiemTypes.Identifier = new DiemTypes.Identifier("transfer");
     const script = new DiemTypes.ScriptFunction(module_id, function_name, tyArgs, args);
     return new DiemTypes.TransactionPayloadVariantScriptFunction(script);
@@ -242,7 +242,7 @@ export class Stdlib {
     }
   }
 
-  static SET_MESSAGE_CODE = Stdlib.fromHexString('a11ceb0b0400000005010002030205050705070c1408201000000001000100020c0a0200074d6573736167650b7365745f6d65737361676568a030d5b64b810a27907665e4c676c4000001040b000b01110002');
+  static SET_MESSAGE_CODE = Stdlib.fromHexString('a11ceb0b0400000005010002030205050705070c1408201000000001000100020c0a0200074d6573736167650b7365745f6d6573736167657ac1be84e53cacbf86fbbc2de4b197c9000001040b000b01110002');
 
   static ScriptArgs: {[name: string]: ScriptDef} = {
     SetMessage: {

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -9,7 +9,7 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 /// When signing transactions for such chains, the numerical chain ID should still be used
 /// (e.g. MAINNET has numeric chain ID 1, TESTNET has chain ID 2, etc)
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, Serialize)] ///////// 0L ////////
+#[derive(Copy, Clone, Debug, Serialize, PartialEq)] ///////// 0L ////////
 pub enum NamedChain {
     /// Users might accidentally initialize the ChainId field to 0, hence reserving ChainId 0 for accidental
     /// initialization.


### PR DESCRIPTION
Fix `shuffle` to use in 0L usecases.

- [x] init accounts from mnemonic
- [x] allow publishing in mainnet or testnet
- [x] can deploy using mnemonic (without needing to store keys locally)