### PR TITLE
V6 fix genesis

### DIFF
--- a/config/management/genesis/src/builder.rs
+++ b/config/management/genesis/src/builder.rs
@@ -66,14 +66,14 @@ impl<S: KVStorage> GenesisBuilder<S> {
 
     pub fn set_root_key(&mut self, root_key: Ed25519PublicKey) -> Result<()> {
         let layout = self.layout()?;
-        self.with_namespace_mut(&layout.diem_root)
+        self.with_namespace_mut(DIEM_ROOT_KEY)
             .set(DIEM_ROOT_KEY, root_key)
             .map_err(Into::into)
     }
 
     pub fn root_key(&self) -> Result<Ed25519PublicKey> {
         let layout = self.layout()?;
-        self.with_namespace(&layout.diem_root)
+        self.with_namespace(DIEM_ROOT_KEY)
             .get(DIEM_ROOT_KEY)
             .map(|r| r.value)
             .map_err(Into::into)

--- a/config/management/genesis/src/builder.rs
+++ b/config/management/genesis/src/builder.rs
@@ -10,6 +10,7 @@ use diem_global_constants::{
 use diem_management::constants::{self, VALIDATOR_CONFIG, VALIDATOR_OPERATOR};
 use diem_secure_storage::{KVStorage, Namespaced};
 use diem_types::{
+    account_address::AccountAddress,
     chain_id::ChainId,
     on_chain_config::{OnChainConsensusConfig, VMPublishingOption},
     transaction::{
@@ -17,7 +18,6 @@ use diem_types::{
     },
 };
 use vm_genesis::{GenesisMiningProof, Validator};
-
 pub struct GenesisBuilder<S> {
     storage: S,
 }
@@ -48,6 +48,7 @@ impl<S: KVStorage> GenesisBuilder<S> {
             .with_namespace(constants::COMMON_NS)
             .get::<String>(constants::LAYOUT)?
             .value;
+        dbg!(&raw_layout);
         Layout::parse(&raw_layout).map_err(Into::into)
     }
 
@@ -136,8 +137,9 @@ impl<S: KVStorage> GenesisBuilder<S> {
         let mut validators = Vec::new();
         for owner in &layout.owners {
             let name = owner.as_bytes().to_vec();
-            let address = diem_config::utils::default_validator_owner_auth_key_from_name(&name)
-                .derived_address();
+            let address = AccountAddress::from_hex(owner)?;
+            // let address = diem_config::utils::default_validator_owner_auth_key_from_name(&name)
+            //     .derived_address();
             let auth_key = self
                 .owner_key(owner)
                 .map_or(AuthenticationKey::zero(), |k| {

--- a/config/management/genesis/src/builder.rs
+++ b/config/management/genesis/src/builder.rs
@@ -223,14 +223,14 @@ impl<S: KVStorage> GenesisBuilder<S> {
         consensus_config: OnChainConsensusConfig,
     ) -> Result<Transaction> {
         /////// 0L /////////
-        let diem_root_key = self.root_key()?;
+        let diem_root_key = self.root_key().ok();
         // let treasury_compliance_key = self.treasury_compliance_key()?;
         let validators = self.validators()?;
         // let move_modules = self.move_modules()?;
         let move_modules = diem_framework_releases::current_module_blobs().to_vec();
 
         let genesis = vm_genesis::encode_genesis_transaction(
-            Some(&diem_root_key), /////// 0L /////////
+            diem_root_key.as_ref(), /////// 0L /////////
             None, // treasury_compliance_key, /////// 0L /////////
             &validators,
             &move_modules,

--- a/config/management/genesis/src/builder.rs
+++ b/config/management/genesis/src/builder.rs
@@ -226,7 +226,8 @@ impl<S: KVStorage> GenesisBuilder<S> {
         let diem_root_key = self.root_key()?;
         // let treasury_compliance_key = self.treasury_compliance_key()?;
         let validators = self.validators()?;
-        let move_modules = self.move_modules()?;
+        // let move_modules = self.move_modules()?;
+        let move_modules = diem_framework_releases::current_module_blobs().to_vec();
 
         let genesis = vm_genesis::encode_genesis_transaction(
             Some(&diem_root_key), /////// 0L /////////

--- a/config/management/genesis/src/layout.rs
+++ b/config/management/genesis/src/layout.rs
@@ -19,7 +19,7 @@ use structopt::StructOpt;
 pub struct Layout {
     pub operators: Vec<String>,
     pub owners: Vec<String>,
-    pub diem_root: String,
+    // pub diem_root: String, //////// 0L /////////
     // pub treasury_compliance: String, //////// 0L /////////
 }
 

--- a/config/management/genesis/src/ol_node_files.rs
+++ b/config/management/genesis/src/ol_node_files.rs
@@ -241,7 +241,7 @@ fn make_genesis_file(
     layout_path: &Option<PathBuf>,
     storage_helper: StorageHelper,
     chain_id: ChainId,
-    namespace: &str,
+    _namespace: &str,
 ) -> Result<(PathBuf, Waypoint), anyhow::Error> {
     let genesis_path = output_dir.join("genesis.blob");
     match prebuilt_genesis {
@@ -256,11 +256,10 @@ fn make_genesis_file(
         None => {
             if repo.is_some() && github_org.is_some() {
                 let remote = format!(
-                    "backend=github;repository_owner={github_org};repository={repo};token={path};namespace={ns}",
+                    "backend=github;repository_owner={github_org};repository={repo};token={path}",
                     repo = repo.as_ref().unwrap(),
                     github_org = github_org.as_ref().unwrap(),
                     path = output_dir.join("github_token.txt").to_str().unwrap(),
-                    ns = &namespace
                 );
                 // building a genesis file requires a set_layout path. The default is for genesis to use a local set_layout file. Once a genesis occurs, the canonical chain can store the genesis information to github repo for future verification and creating a genesis blob.
                 let genesis_waypoint = match layout_path {

--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -63,18 +63,7 @@ impl StorageHelper {
     pub fn initialize_with_mnemonic_swarm(&self, namespace: String, mnemonic: String) {
         let keys = KeyScheme::new_from_mnemonic(mnemonic);
         let mut storage = self.storage(namespace.clone());
-        // let mut rng: rand::rngs::StdRng = rand::SeedableRng::from_seed([5; 32]);
-        // let dummy_root = Ed25519PrivateKey::from_encoded_string(
-        //     "8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010"
-        // ).unwrap();
 
-        // storage
-        //     .import_private_key(DIEM_ROOT_KEY, dummy_root.clone())
-        //     .unwrap();
-        // // let diem_root_key = storage_owner.export_private_key(DIEM_ROOT_KEY).unwrap();
-        // storage
-        //     .import_private_key(TREASURY_COMPLIANCE_KEY, dummy_root)
-        //     .unwrap();
         storage
             .import_private_key(OWNER_KEY, keys.child_0_owner.get_private_key())
             .unwrap();
@@ -123,17 +112,18 @@ impl StorageHelper {
 
         if is_genesis {
             // Data needed for testnet, swarm, and genesis ceremony.
-            let mut storage_root = self.storage("root".to_owned());
-            let dummy_root = Ed25519PrivateKey::from_encoded_string(
-                "8108aedfacf5cf1d73c67b6936397ba5fa72817f1b5aab94658238ddcdc08010" // protests rage accross the nation
-            ).unwrap();
+            // let mut storage_root = self.storage("root".to_owned());
+            // let dummy_root_for_swarm = Ed25519PrivateKey::from_encoded_string(
+            //   //  "50726f7465737473207261676520616363726f737320746865206e6174696f6e"// 
+            //     &hex::encode("Protests rage accross the nation")
+            // ).unwrap();
 
-            storage_root
-                .import_private_key(DIEM_ROOT_KEY, dummy_root.clone())
-                .unwrap();
-            storage_root
-                .import_private_key(TREASURY_COMPLIANCE_KEY, dummy_root)
-                .unwrap();
+            // storage_root
+            //     .import_private_key(DIEM_ROOT_KEY, dummy_root_for_swarm.clone())
+            //     .unwrap();
+            // storage_root
+            //     .import_private_key(TREASURY_COMPLIANCE_KEY, dummy_root_for_swarm)
+            //     .unwrap();
             storage_owner
                 .import_private_key(OWNER_KEY, keys.child_0_owner.get_private_key())
                 .unwrap();

--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -422,7 +422,7 @@ impl ValidatorBuilder {
         let layout = Layout {
             owners: validators.iter().map(|v| v.owner()).collect(),
             operators: validators.iter().map(|v| v.operator()).collect(),
-            diem_root: DIEM_ROOT_NS.into(),
+            // diem_root: DIEM_ROOT_NS.into(),
             // treasury_compliance: DIEM_ROOT_NS.into(), /////// 0L /////////
         };
         genesis_builder.set_layout(&layout)?;

--- a/crates/diem-wallet/src/key_factory.rs
+++ b/crates/diem-wallet/src/key_factory.rs
@@ -136,9 +136,11 @@ pub struct KeyFactory {
 }
 
 impl KeyFactory {
-    const MNEMONIC_SALT_PREFIX: &'static [u8] = b"DIEM WALLET: mnemonic salt prefix$";
-    const MAIN_KEY_SALT: &'static [u8] = b"DIEM WALLET: main key salt$";
-    const INFO_PREFIX: &'static [u8] = b"DIEM WALLET: derived key$";
+    //////// 0L ////////
+    const MNEMONIC_SALT_PREFIX: &'static [u8] = b"0L WALLET: UNREST, FIRES, AND VIOLENCE AS PROTESTS RAGE ACROSS US: mnemonic salt prefix$"; // https://markets.businessinsider.com/news/stocks/why-stock-market-rising-amid-nationwide-police-brutality-protests-2020-6-1029273996
+    const MAIN_KEY_SALT: &'static [u8] = b"0L WALLET: 30 MILLION AMERICANS HAVE FILED INITIAL UNEMPLOYMENT CLAIMS: master key salt$"; // https://www.cnn.com/2020/04/30/economy/unemployment-benefits-coronavirus/index.html
+    const INFO_PREFIX: &'static [u8] = b"0L WALLET: US DEATHS NEAR 100,000, AN INCALCULABLE LOSS: derived key$"; // https://www.nytimes.com/interactive/2020/05/24/us/us-coronavirus-deaths-100000.html
+    
     /// Instantiate a new KeyFactor from a Seed, where the [u8; 64] raw bytes of the Seed are used
     /// to derive both the Main and its child keys
     pub fn new(seed: &Seed) -> Result<Self> {

--- a/crates/diem-wallet/src/wallet_library.rs
+++ b/crates/diem-wallet/src/wallet_library.rs
@@ -50,7 +50,7 @@ impl WalletLibrary {
 
     /// Constructor that instantiates a new WalletLibrary from Mnemonic
     pub fn new_from_mnemonic(mnemonic: Mnemonic) -> Self {
-        let seed = Seed::new(&mnemonic, "DIEM");
+        let seed = Seed::new(&mnemonic, "0L"); //////// 0L ////////
         WalletLibrary {
             mnemonic,
             key_factory: KeyFactory::new(&seed).unwrap(),

--- a/ol/keys/src/wallet.rs
+++ b/ol/keys/src/wallet.rs
@@ -122,6 +122,26 @@ fn wallet() {
     assert!(vec_addresses.len() == 1);
 }
 
+#[test]
+fn fixture_wallet() {
+    use diem_wallet::Mnemonic;
+    
+    // alice
+    let mnemonic_string = "talent sunset lizard pill fame nuclear spy noodle basket okay critic grow sleep legend hurry pitch blanket clerk impose rough degree sock insane purse";
+
+
+    let mut wallet = WalletLibrary::new_from_mnemonic(Mnemonic::from(&mnemonic_string).unwrap());
+
+    let (main_addr, child_number) = wallet.new_address().unwrap();
+    println!("wallet\n:{:?} === {:x}", child_number, main_addr);
+
+    let (_, acc, _) = get_account_from_mnem(mnemonic_string.to_owned()).unwrap();
+    dbg!(&acc);
+
+    // expect the same address for alice
+    assert!(&acc.to_string() == "4C613C2F4B1E67CA8D98A542EE3F59F5");
+}
+
 // TODO: this is duplicated with ol/types/config because of a dependency cycle. Move to Global constants?
 /// check this is CI environment
 pub static IS_TEST: Lazy<bool> = Lazy::new(|| {


### PR DESCRIPTION
Genesis tools had to be refactored given changes to testsuites.

- [x] patch Makefile for Genesis in testnet
- [x] patch account fixtures for testnet
- [x] refactor the default genesis builder, and cleanup