### PR TITLE
Refactor clone usage in CLI node folder

### DIFF
--- a/ol/cli/src/node/account.rs
+++ b/ol/cli/src/node/account.rs
@@ -218,8 +218,8 @@ impl Node {
             Ok(account_state) => {
                 let handles = account_state.get_diem_account_resource()?.map(|resource| {
                     (
-                        resource.sent_events().clone(),
-                        resource.received_events().clone(),
+                        resource.sent_events().to_owned(),
+                        resource.received_events().to_owned(),
                     )
                 });
                 Ok(handles)

--- a/ol/cli/src/node/autopay_view.rs
+++ b/ol/cli/src/node/autopay_view.rs
@@ -27,7 +27,7 @@ pub struct PayeeStats {
 
 impl Node {
     /// Get all percentage recurring payees stats
-    pub fn get_autopay_watch_list(&self, vals: Vec<ValidatorView>) -> Option<Vec<PayeeStats>> {
+    pub fn get_autopay_watch_list(&self, vals: &Vec<ValidatorView>) -> Option<Vec<PayeeStats>> {
         let mut payees: HashMap<AccountAddress, PayeeSums> = HashMap::new();
         let mut total: u64 = 0;
 

--- a/ol/cli/src/node/chain_view.rs
+++ b/ol/cli/src/node/chain_view.rs
@@ -193,8 +193,8 @@ impl Node {
 
             cs.validator_view = Some(validators.clone());
             cs.validators_stats = Some(validators_stats);
-            cs.vals_config_stats = calc_config_stats(validators.clone()).ok();
-            cs.autopay_watch_list = self.get_autopay_watch_list(validators.clone());
+            cs.vals_config_stats = calc_config_stats(&validators).ok();
+            cs.autopay_watch_list = self.get_autopay_watch_list(&validators);
             cs.upgrade = self.client.get_oracle_upgrade_state()?.into_inner();
 
             self.vitals.chain_view = Some(cs.clone());
@@ -288,13 +288,13 @@ impl Node {
     }
 }
 
-fn calc_config_stats(vals: Vec<ValidatorView>) -> Result<ValsConfigStats, Error> {
+fn calc_config_stats(vals: &Vec<ValidatorView>) -> Result<ValsConfigStats, Error> {
     let mut count_autopay = 0;
     let mut count_operators = 0;
     let mut count_positive_balance = 0;
 
     for val in vals.iter() {
-        if let Some(config) = val.validator_config.clone() {
+        if let Some(config) = &val.validator_config {
             if let Some(a) = &val.autopay {
                 if a.payments.iter().any(|each| each.is_percent_of_change()) {
                     count_autopay += 1;
@@ -334,7 +334,7 @@ fn _scan_port(ip: &String, port: &u16) -> bool {
     let timeout = Duration::from_millis(200);
     match IpAddr::from_str(ip) {
         Ok(address) => {
-            let socket_address = SocketAddr::new(address, port.clone());
+            let socket_address = SocketAddr::new(address, *port);
             match TcpStream::connect_timeout(&socket_address, timeout) {
                 Ok(_) => true,
                 _ => false,

--- a/ol/cli/src/node/client.rs
+++ b/ol/cli/src/node/client.rs
@@ -24,7 +24,7 @@ pub fn make_client(url: Option<Url>) -> Result<DiemClient, Error> {
 pub fn get_client() -> Option<DiemClient> {
     let config = app_config();
     for url in &config.profile.upstream_nodes {
-        let client = DiemClient::new(url.clone());
+        let client = DiemClient::new(url.to_owned());
         // TODO: What's the better way to check we can connect to client?
         let metadata = client.get_metadata();
         if metadata.is_ok() {
@@ -85,7 +85,7 @@ pub fn default_local_rpc() -> Result<DiemClient, Error> {
 /// connect a swarm client
 pub fn swarm_test_client(swarm_path: PathBuf) -> Result<DiemClient, Error> {
     let (url, _) = ol_types::config::get_swarm_rpc_url(swarm_path.clone());
-    make_client(Some(url.clone()))
+    make_client(Some(url))
 }
 
 /// picks what URL to connect to based on sync state. Or returns the client for swarm.

--- a/ol/cli/src/node/dictionary.rs
+++ b/ol/cli/src/node/dictionary.rs
@@ -42,7 +42,7 @@ impl AccountDictionary {
     /// return a note for the account address
     pub fn get_note_for_address(&self, address: AccountAddress) -> String {
         match self.accounts.iter().find(|entry| entry.address == address) {
-            Some(found) => found.note.clone(),
+            Some(found) => found.note.to_owned(),
             None => String::from(""),
         }
     }

--- a/ol/cli/src/node/node.rs
+++ b/ol/cli/src/node/node.rs
@@ -90,7 +90,7 @@ impl Node {
     /// default node connection from configs
     pub fn default_from_cfg(mut cfg: AppCfg, swarm_path: Option<PathBuf>) -> Node {
         // NOTE: not intended for swarm.
-        let client = client::pick_client(swarm_path.clone(), &mut cfg).unwrap();
+        let client = client::pick_client(swarm_path.to_owned(), &mut cfg).unwrap();
         Node::new(client, &cfg, swarm_path.is_some())
     }
 
@@ -194,7 +194,7 @@ impl Node {
     /// nothing is configured yet, empty box
     pub fn configs_exist(&mut self) -> bool {
         // check to see no files are present
-        let home_path = self.app_conf.workspace.node_home.clone();
+        let home_path = self.app_conf.workspace.node_home.to_owned();
 
         let c_exist = home_path.join("vdf_proofs/proof_0.json").exists()
             && home_path.join("validator.node.yaml").exists()
@@ -214,7 +214,7 @@ impl Node {
 
     /// database is initialized, Please do NOT invoke this function frequently
     pub fn db_bootstrapped(&mut self) -> bool {
-        let file = self.app_conf.workspace.db_path.clone();
+        let file = self.app_conf.workspace.db_path.to_owned();
         if file.exists() {
             // When not committing, we open the DB as secondary so the tool
             // is usable along side a running node on the same DB.
@@ -232,7 +232,7 @@ impl Node {
     /// database is initialized, Please do NOT invoke this function frequently
     pub fn db_files_exist(&mut self) -> bool {
         // check to see no files are present
-        let db_path = self.app_conf.workspace.db_path.clone().join("diemdb");
+        let db_path = self.app_conf.workspace.db_path.to_owned().join("diemdb");
         db_path.exists()
     }
 

--- a/ol/cli/src/node/query.rs
+++ b/ol/cli/src/node/query.rs
@@ -459,7 +459,7 @@ pub fn test_fixture_struct() -> AnnotatedMoveStruct {
 
     AnnotatedMoveStruct {
         abilities: AbilitySet::EMPTY | Ability::Key,
-        type_: module_tag.clone(),
+        type_: module_tag,
         value: vec![(key, value)],
     }
 }
@@ -480,7 +480,7 @@ pub fn test_fixture_wallet_type(
 
     let move_struct = AnnotatedMoveStruct {
         abilities: AbilitySet::EMPTY | Ability::Key,
-        type_: module_tag.clone(),
+        type_: module_tag,
         value,
     };
     s.insert(move_struct.type_.clone(), move_struct);


### PR DESCRIPTION

## Motivation

This PR is to refactor some `.clones` as part of the Tool Scrubbers Guild Tasks. It contains 15 instances of `.clone()` cleanup. Some may not be applicable but would be good material for the Guild meeting. See comments 



## Test Plan

`cargo test` 

## Related PRs

N/A
