### PR TITLE
Added a step in smoke tests phase to cleanup space on runner machine

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -4,6 +4,12 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
+      - name: Clean up space on runner machine
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Check out
         uses: actions/checkout@v3
       - name: Set up cargo cache
@@ -15,12 +21,12 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - name: Install deps
         run: sudo apt-get install -y lld
-        
+
       - name: build stdlib
         run: make stdlib
 


### PR DESCRIPTION
The CI pipeline under the github actions was failing on the smoke tests due to running out of space on runner machine. It is a bit surprising given that the runner machine supposedly has 14GB of space available, but anyhow :shrug: 

[Here](https://github.com/actions/runner-images/issues/2840#issuecomment-790492173) I found proposed solution.

Added a `space cleaning` step before the runner starts the bootstrapping and tested locally using a local github actions tester called [Act](https://github.com/nektos/act).
(which had other issues but I think the relevant part was passing correctly).