### PR TITLE
Change "Out of gas" to "Gas bid too low"

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -466,7 +466,7 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
                 AbortLocation::Script => format!("Move abort: code {}", abort_code),
             },
             KeptVMStatus::Executed => "Executed successfully".to_owned(),
-            KeptVMStatus::OutOfGas => "Out of gas".to_owned(),
+            KeptVMStatus::OutOfGas => "Gas bid too low".to_owned(),
             KeptVMStatus::ExecutionFailure {
                 location,
                 function,


### PR DESCRIPTION
This error message refers to the gas tank of an individual transaction. This is misleading. The message is exposed to the end user, who typically understands that his account is out of gas coins." He might not get the idea that he has to update the gas bid in his configs or in his application. When 0L gets popular, this might be frustrating for thousands of users.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the 0L project.
-->

## Test Plan

Trivial, low risk change. The automatic tests suffice. 

