### PR TITLE
Fix vm-genesis fn recovery_owners_operator()

### DIFF
--- a/ol/genesis-tools/src/recover.rs
+++ b/ol/genesis-tools/src/recover.rs
@@ -100,7 +100,7 @@ pub fn accounts_into_recovery(
     let mut to_recover = vec![];
     for blob in account_state_blobs {
         let account_state = AccountState::try_from(blob)?;
-        dbg!(&account_state);
+        // dbg!(&account_state);
         match parse_recovery(&account_state) {
             Ok(gr) => to_recover.push(gr),
             Err(e) => println!(

--- a/ol/genesis-tools/src/recover.rs
+++ b/ol/genesis-tools/src/recover.rs
@@ -46,7 +46,9 @@ pub enum WalletType {
 }
 
 /// The basic structs needed to recover account state in a new network.
-/// This is necessary for catastrophic recoveries, when the source code changes too much. Like what is going to happen between v4 and v5, where the source code of v5 will not be able to work with objects from v4. We need an intermediary file.
+/// This is necessary for catastrophic recoveries, when the source code changes too much. 
+/// Like what is going to happen between v4 and v5, where the source code of v5
+/// will not be able to work with objects from v4. We need an intermediary file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LegacyRecovery {
     ///
@@ -90,7 +92,8 @@ impl Default for RecoverConsensusAccounts {
     }
 }
 
-/// make the writeset for the genesis case. Starts with an unmodified account state and make into a writeset.
+/// make the writeset for the genesis case. Starts with an unmodified account
+/// state and make into a writeset.
 pub fn accounts_into_recovery(
     account_state_blobs: &Vec<AccountStateBlob>,
 ) -> Result<Vec<LegacyRecovery>, Error> {
@@ -271,8 +274,7 @@ pub fn recover_consensus_accounts(
 pub fn save_recovery_file(data: &Vec<LegacyRecovery>, path: &PathBuf) -> Result<(), Error> {
     let j = serde_json::to_string(data)?;
     let mut file = fs::File::create(path).expect("Could not genesis_recovery create file");
-    file.write_all(j.as_bytes())
-        .expect("Could not write account recovery");
+    file.write_all(j.as_bytes()).expect("Could not write account recovery");
     Ok(())
 }
 


### PR DESCRIPTION
## 
Fixing panic (Move error) caused by "Set validator operator for each validator owner" section of `fn recovery_owners_operator`

https://github.com/OLSF/libra/blob/e042010ac22caba6cc9fc70c745b17f1bf7d666a/language/tools/vm-genesis/src/lib.rs#L839

In short, this is the fix: 
https://github.com/OLSF/libra/pull/1210/files#diff-0d5e9369eb26d02a79b4c768f68da66d258aee03b4f19409b5f7b3dc26d440d6L809-R814

tested and verified by cmd: 
`$ cargo run -p ol-genesis-tools -- --fork --output-path /opt/genesis_from_snapshot.blob --snapshot-path /opt/state_ver*`

where `/opt/state_ver` having these files: 
https://github.com/OLSF/epoch-archive/tree/main/359/state_ver_76353076.a0ff


## Details: 
The panic 
```
VMError { 
    major_status: NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH, 
    sub_status: None, message: Some("Expected 2 signer args got 1"), 
    location: Undefined, indices: [], offsets: [] 
}, 
```

is caused by our code
`encode_set_validator_operator_with_nonce_admin_script_function`
This tx is not being used anywhere in original Diem code. 

----

This is how Diem code set the validator operator for each validator owner: 
https://github.com/OLSF/libra/blob/e042010ac22caba6cc9fc70c745b17f1bf7d666a/language/tools/vm-genesis/src/lib.rs#L644
and this is the tx being used: 

`encode_set_validator_operator_script_function`
https://github.com/OLSF/libra/blob/a116e3e75fd4f455b1ab9f5935b9f188c0baafff/language/tools/vm-genesis/src/lib.rs#L578

