### PR TITLE
Remove slow wallet check when completing a community transfer

### DIFF
--- a/diem-move/diem-framework/DPN/sources/0L/Wallet.move
+++ b/diem-move/diem-framework/DPN/sources/0L/Wallet.move
@@ -124,11 +124,6 @@ module Wallet {
     public fun new_timed_transfer(
       sender: &signer, payee: address, value: u64, description: vector<u8>
     ): u64 acquires CommunityTransfers, CommunityWalletList {
-      // firstly check if payee is a slow wallet
-      // TODO: This function should check if the account is a slow wallet before sending
-      // but there's a circular dependency with DiemAccount which has the slow wallet struct.
-      // curretly we move that check to the transaction script to initialize the payment.
-      // assert!(DiemAccount::is_slow(payee), EIS_NOT_SLOW_WALLET);
 
       let sender_addr = Signer::address_of(sender);
       let list = get_comm_list();

--- a/diem-move/diem-framework/DPN/sources/0L_transaction_scripts/ol_transfer.move
+++ b/diem-move/diem-framework/DPN/sources/0L_transaction_scripts/ol_transfer.move
@@ -43,12 +43,6 @@ module TransferScripts {
         let sender_addr = Signer::address_of(&sender);
         assert!(Wallet::is_comm(sender_addr), 30001);
 
-        // confirm the destination account has a slow wallet
-        // TODO: this check only happens in this script since there's 
-        // a circular dependecy issue with DiemAccount and Wallet which impedes
-        // checking in Wallet module
-        assert!(DiemAccount::is_slow(destination), 30002);
-
         let uid = Wallet::new_timed_transfer(&sender, destination, value, memo);
         assert!(Wallet::transfer_is_proposed(uid), 30003);
     }

--- a/diem-move/diem-framework/core/transactional-tests/0L/diem_account/transfer_community_wallet_script.move
+++ b/diem-move/diem-framework/core/transactional-tests/0L/diem_account/transfer_community_wallet_script.move
@@ -2,20 +2,20 @@
 // Alice, Jim:     validators with 10M GAS
 // Bob, Carol: non-validators with  1M GAS
 
-// Bob, the slow wallet
+// Bob, the recipient wallet
 // Carol, the community wallet
 
-// Community wallets cannot use the slow wallet transfer scripts
 
 //# run --admin-script --signers DiemRoot Bob
 script {
   use DiemFramework::DiemAccount;
   use Std::Vector;
 
-  fun main(_dr: signer, bob: signer) {
+  fun main(_dr: signer, _bob: signer) {
     // Genesis creates 6 validators by default which are already slow wallets,
     let list = DiemAccount::get_slow_list();
-    assert!(Vector::length<address>(&list) == 7, 735701);
+    //verify bob is not in the slow list
+    assert!(Vector::length<address>(&list) == 6, 735701);
   }
 }
 

--- a/diem-move/diem-framework/core/transactional-tests/0L/diem_account/transfer_community_wallet_script.move
+++ b/diem-move/diem-framework/core/transactional-tests/0L/diem_account/transfer_community_wallet_script.move
@@ -14,8 +14,6 @@ script {
 
   fun main(_dr: signer, bob: signer) {
     // Genesis creates 6 validators by default which are already slow wallets,
-    // adding Bob
-    DiemAccount::set_slow(&bob);
     let list = DiemAccount::get_slow_list();
     assert!(Vector::length<address>(&list) == 7, 735701);
   }


### PR DESCRIPTION
## Motivation

At the moment, community wallets can send GAS only to slow wallets. It doesn’t make sense. 
Slow wallets were made to prevent validators and early contributors that were granted large amounts of GAS, from dumping on the market and move the price too much.

People that are receiving bounties, “employees“, etc. all of those, should have no limitations to spend their “well earned“ GAS.

This PR removes the checks on the payee acc being a slow wallet when making community transfers.

## Test Plan

Refer to comment below

## Related PRs

N/A
