### PR TITLE
Update backlog.rs

### DIFF
--- a/ol/tower/src/backlog.rs
+++ b/ol/tower/src/backlog.rs
@@ -23,77 +23,82 @@ use crate::{tower_errors, EPOCH_MINING_THRES_UPPER};
 pub fn process_backlog(config: &AppCfg, tx_params: &TxParams) -> Result<(), TxError> {
     // Getting remote miner state
     // there may not be any onchain state.
-    let (remote_height, proofs_in_epoch) = get_remote_tower_height(tx_params)?;
-
-    info!("Remote tower height: {}", remote_height);
-    info!("Proofs already submitted in epoch: {}", proofs_in_epoch);
-    // Getting local state height
-    let mut blocks_dir = config.workspace.node_home.clone();
-    blocks_dir.push(&config.workspace.block_dir);
-
-    let (current_local_proof, _current_block_path) = get_highest_block(&blocks_dir)?;
-
-    let current_proof_number = current_local_proof.height;
-    // if let Some(current_proof_number) = current_local_proof {
-    info!("Local tower height: {:?}", current_proof_number);
-    if remote_height < 0 || current_proof_number > remote_height as u64 {
-        let mut i = remote_height as u64 + 1;
-
-        // use i64 for safety
-        if !(proofs_in_epoch < EPOCH_MINING_THRES_UPPER as i64) {
-            info!(
-                "Backlog: Maximum number of proofs sent this epoch {}, exiting.",
-                EPOCH_MINING_THRES_UPPER
-            );
-            return Err(anyhow!(
-                "cannot submit more proofs than allowed in epoch, aborting backlog."
-            )
-            .into());
-        }
-
-        let remaining_in_epoch = if proofs_in_epoch > 0 {
-            EPOCH_MINING_THRES_UPPER - proofs_in_epoch as u64
-        } else {
-            EPOCH_MINING_THRES_UPPER
-        };
-        let mut submitted_now = 1u64;
-
-        info!("Backlog: resubmitting missing proofs. Remaining in epoch: {}, already submitted in this backlog: {}", remaining_in_epoch, submitted_now);
-
-        while i <= current_proof_number && submitted_now <= remaining_in_epoch {
-            info!("submitting proof {}, in this backlog: {}", i, submitted_now);
-
-            let path = PathBuf::from(format!("{}/{}_{}.json", blocks_dir.display(), FILENAME, i));
-
-            let file = File::open(&path).map_err(|e| {
-                anyhow!("failed to open file: {:?}, message, {}", &path.to_str(), e.to_string())
-            })?;
-
-            let reader = BufReader::new(file);
-            let block: VDFProof = serde_json::from_reader(reader).map_err(|e| Error::from(e))?;
-
-            let view = commit_proof_tx(&tx_params, block.clone())?;
-            match eval_tx_status(view) {
-                Ok(_) => {}
-                Err(e) => {
-                    warn!(
-                        "WARN: could not fetch TX status, aborting. Message: {:?} ",
-                        &e
+    match get_remote_tower_height(tx_params){
+        Ok((remote_height, proofs_in_epoch)) => {
+            info!("Remote tower height: {}", remote_height);
+            info!("Proofs already submitted in epoch: {}", proofs_in_epoch);
+            // Getting local state height
+            let mut blocks_dir = config.workspace.node_home.clone();
+            blocks_dir.push(&config.workspace.block_dir);
+        
+            let (current_local_proof, _current_block_path) = get_highest_block(&blocks_dir)?;
+        
+            let current_proof_number = current_local_proof.height;
+            // if let Some(current_proof_number) = current_local_proof {
+            info!("Local tower height: {:?}", current_proof_number);
+            if remote_height < 0 || current_proof_number > remote_height as u64 {
+                let mut i = remote_height as u64 + 1;
+        
+                // use i64 for safety
+                if !(proofs_in_epoch < EPOCH_MINING_THRES_UPPER as i64) {
+                    info!(
+                        "Backlog: Maximum number of proofs sent this epoch {}, exiting.",
+                        EPOCH_MINING_THRES_UPPER
                     );
-                    // evaluate type of error and maybe garbage collect
-                    match tower_errors::parse_error(&e) {
-                        tower_errors::TowerError::WrongDifficulty => gc_failed_proof(config, path)?,
-                        tower_errors::TowerError::Discontinuity => gc_failed_proof(config, path)?,
-                        tower_errors::TowerError::Invalid => gc_failed_proof(config, path)?,
-                        _ => {}
-                    }
-                    return Err(e);
+                    return Err(anyhow!(
+                        "cannot submit more proofs than allowed in epoch, aborting backlog."
+                    )
+                    .into());
                 }
-            };
-            i = i + 1;
-            submitted_now = submitted_now + 1;
+        
+                let remaining_in_epoch = if proofs_in_epoch > 0 {
+                    EPOCH_MINING_THRES_UPPER - proofs_in_epoch as u64
+                } else {
+                    EPOCH_MINING_THRES_UPPER
+                };
+                let mut submitted_now = 1u64;
+        
+                info!("Backlog: resubmitting missing proofs. Remaining in epoch: {}, already submitted in this backlog: {}", remaining_in_epoch, submitted_now);
+        
+                while i <= current_proof_number && submitted_now <= remaining_in_epoch {
+                    info!("submitting proof {}, in this backlog: {}", i, submitted_now);
+        
+                    let path = PathBuf::from(format!("{}/{}_{}.json", blocks_dir.display(), FILENAME, i));
+        
+                    let file = File::open(&path).map_err(|e| {
+                        anyhow!("failed to open file: {:?}, message, {}", &path.to_str(), e.to_string())
+                    })?;
+        
+                    let reader = BufReader::new(file);
+                    let block: VDFProof = serde_json::from_reader(reader).map_err(|e| Error::from(e))?;
+        
+                    let view = commit_proof_tx(&tx_params, block.clone())?;
+                    match eval_tx_status(view) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            warn!(
+                                "WARN: could not fetch TX status, aborting. Message: {:?} ",
+                                &e
+                            );
+                            // evaluate type of error and maybe garbage collect
+                            match tower_errors::parse_error(&e) {
+                                tower_errors::TowerError::WrongDifficulty => gc_failed_proof(config, path)?,
+                                tower_errors::TowerError::Discontinuity => gc_failed_proof(config, path)?,
+                                tower_errors::TowerError::Invalid => gc_failed_proof(config, path)?,
+                                _ => {}
+                            }
+                            return Err(e);
+                        }
+                    };
+                    i = i + 1;
+                    submitted_now = submitted_now + 1;
+                }
+                // }
+            }
         }
-        // }
+        Err(_e) => {
+            maybe_send_genesis_proof(config, tx_params)?;
+        }
     }
     Ok(())
 }
@@ -106,57 +111,64 @@ pub fn submit_proof_by_number(
 ) -> Result<(), TxError> {
     // Getting remote miner state
     // there may not be any onchain state.
-    let (remote_height, _proofs_in_epoch) = get_remote_tower_height(tx_params)?;
+    match get_remote_tower_height(tx_params){
+        Ok((remote_height, _proofs_in_epoch)) => {
+            info!("Remote tower height: {}", remote_height);
+            // Getting local state height
+            let mut blocks_dir = config.workspace.node_home.clone();
+            blocks_dir.push(&config.workspace.block_dir);
+            let (current_local_proof, _current_block_path) = get_highest_block(&blocks_dir)?;
+            let current_proof_number = current_local_proof.height;
+            // if let Some(current_proof_number) = current_local_proof {
+            info!("Local tower height: {:?}", current_proof_number);
 
-    info!("Remote tower height: {}", remote_height);
-    // Getting local state height
-    let mut blocks_dir = config.workspace.node_home.clone();
-    blocks_dir.push(&config.workspace.block_dir);
-    let (current_local_proof, _current_block_path) = get_highest_block(&blocks_dir)?;
-    let current_proof_number = current_local_proof.height;
-    // if let Some(current_proof_number) = current_local_proof {
-    info!("Local tower height: {:?}", current_proof_number);
+            if proof_to_submit > current_proof_number {
+                warn!(
+                    "unable to submit proof - local tower height is smaller than {:?}",
+                    proof_to_submit
+                );
+                return Ok(());
+            }
 
-    if proof_to_submit > current_proof_number {
-        warn!(
-            "unable to submit proof - local tower height is smaller than {:?}",
-            proof_to_submit
-        );
-        return Ok(());
-    }
+            if remote_height > 0 && proof_to_submit <= remote_height as u64 {
+                warn!(
+                    "unable to submit proof - remote tower height is higher than or equal to {:?}",
+                    proof_to_submit
+                );
+                return Ok(());
+            }
 
-    if remote_height > 0 && proof_to_submit <= remote_height as u64 {
-        warn!(
-            "unable to submit proof - remote tower height is higher than or equal to {:?}",
-            proof_to_submit
-        );
-        return Ok(());
-    }
+            info!("Backlog: submitting proof {:?}", proof_to_submit);
 
-    info!("Backlog: submitting proof {:?}", proof_to_submit);
+            let path = PathBuf::from(format!(
+                "{}/{}_{}.json",
+                blocks_dir.display(),
+                FILENAME,
+                proof_to_submit
+            ));
+            let file = File::open(&path).map_err(|e| Error::from(e))?;
 
-    let path = PathBuf::from(format!(
-        "{}/{}_{}.json",
-        blocks_dir.display(),
-        FILENAME,
-        proof_to_submit
-    ));
-    let file = File::open(&path).map_err(|e| Error::from(e))?;
+            let reader = BufReader::new(file);
+            let block: VDFProof = serde_json::from_reader(reader).map_err(|e| Error::from(e))?;
 
-    let reader = BufReader::new(file);
-    let block: VDFProof = serde_json::from_reader(reader).map_err(|e| Error::from(e))?;
-
-    let view = commit_proof_tx(&tx_params, block)?;
-    match eval_tx_status(view) {
-        Ok(_) => {}
-        Err(e) => {
-            warn!(
-                "WARN: could not fetch TX status, aborting. Message: {:?} ",
-                e
-            );
-            return Err(e);
-        } // };
-    }
+            let view = commit_proof_tx(&tx_params, block)?;
+            match eval_tx_status(view) {
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(
+                        "WARN: could not fetch TX status, aborting. Message: {:?} ",
+                        e
+                    );
+                    return Err(e);
+                } // };
+            }
+        }
+        Err(_e) => {
+            if proof_to_submit == 0 {
+                maybe_send_genesis_proof(config, tx_params)?;
+            }
+        }
+    }    
     Ok(())
 }
 
@@ -226,4 +238,44 @@ pub fn get_remote_tower_height(tx_params: &TxParams) -> Result<(i64, i64), Error
             return Err(e);
         }
     }
+}
+
+/// submit genesis proof
+pub fn maybe_send_genesis_proof(config: &AppCfg, tx_params: &TxParams) -> Result<(), TxError> {
+    // check if the tower state has been initialized.
+    // otherwise this is a genesis proof.
+  
+    // check if any proof_0.json has been mined
+    if let Some(proof) = get_proof_zero(config).ok() {
+      match commit_proof_tx(tx_params, proof) {
+        Ok(_) => {
+          println!("submitted proof zero");
+          Ok(())
+        }
+        Err(e) => {
+          dbg!(&e);
+          Err(TxError::from(e))
+        }
+      }
+    } else {
+      error!("No genesis proof found in vdf_proofs dir");
+      Ok(())
+    }
+  }
+  
+  fn get_proof_zero(config: &AppCfg) -> Result<VDFProof, Error> {
+    let mut blocks_dir = config.workspace.node_home.clone();
+    blocks_dir.push(&config.workspace.block_dir);
+    let genesis_roof_number = 0;
+    let path = PathBuf::from(format!(
+        "{}/{}_{}.json",
+        blocks_dir.display(),
+        FILENAME,
+        genesis_roof_number
+    ));
+    let file = File::open(&path).map_err(|e| Error::from(e))?;
+
+    let reader = BufReader::new(file);
+    let proof: VDFProof = serde_json::from_reader(reader).map_err(|e| Error::from(e))?;  
+    Ok(proof)
 }


### PR DESCRIPTION
When using tower to mine genesis proof as normal user accounts, there always be a error `unable to get tower height from chain` when submitting it.
Indeed that there will be no tower state on the chain until you upload any proof, I copied some code form carpe and added it to backlog.rs, it can submit genesis proof normally now
