### PR TITLE
V6 testdoc

### DIFF
--- a/ol/documentation/core-devs/_V6_test_cheatsheet.md
+++ b/ol/documentation/core-devs/_V6_test_cheatsheet.md
@@ -1,0 +1,26 @@
+## Build Move Binaries
+Usually a safe bet to do this before any tests. Smoketests and Forge tests depend on this step. 
+
+Functional aka transactional tests do not depend on this step (but things could get weird if the binary outputs are not found in the right places).
+
+```
+sh ol/util/build-stdlib.sh
+```
+
+## Run Functional Move Tests aka Transactional Tests
+```
+NODE_ENV="test" cargo test -p diem-framework --test ol_transactional_tests <optional keyword>
+```
+
+## Run 0L smoke Tests
+
+The 0L smoke tests exists outside of the Diem default smoke tests and Forge suite.
+
+```
+cd ol/smoke-tests
+cargo test -- --test-threads=1
+```
+TODO: add a mining test, to replace the e2e shell scripts
+
+# Default Diem Forge and Smoketests
+[See documentation here for Diem tests.](./smoke_tests.md)

--- a/ol/documentation/core-devs/smoke_tests.md
+++ b/ol/documentation/core-devs/smoke_tests.md
@@ -1,11 +1,13 @@
-
-## Run forge tests
+As of Jan 23rd 2022, these tests aren't all passing. And some have false positives.
+## Run default Forge suite
+```
 cargo r -p forge-cli -- test local-swarm
+```
 
-## run smoke tests
+## run default smoke tests (based on Forge)
 `cargo x` is a libra hack and runs the compilation and tests in the foreground.
 
 cargo x test --package smoke-test -- `<test name>`
 
-### get list of smoke tests
+### get list of default smoke tests
 cargo x test --package smoke-test -- --list


### PR DESCRIPTION
There was some missing documentation on how to run some basic tests on v6.

The transactional (functional) tests have a new api. And Forge and Smoke Tests are the latest frameworks to this version. Those were undocumented. 

We've also added and 0L specific smoke tests based on the added Forge/Smoketests architecture.