### PR TITLE
update no-build-docs developer tip

### DIFF
--- a/ol/util/build-stdlib.sh
+++ b/ol/util/build-stdlib.sh
@@ -9,6 +9,6 @@ printf "This builds:
 
 cd diem-move/diem-framework
 cargo r --release -- $1
-# cargo r --release -- $1 --no-doc # for dev. quick iteration
+# cargo r --release -- $1 --no-build-docs # for dev. quick iteration
 
 printf "Done\n"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the 0L project.
-->
## Motivation

Fix build instruction tip for developer. The suggested argument (`--no-doc`) is invalid. The correct one is `--no-build-docs`.