### PR TITLE
[Genesis] V6 refactor account state migration to use VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6571,6 +6571,7 @@ dependencies = [
  "diem-wallet",
  "futures",
  "gumdrop 0.8.1",
+ "language-e2e-tests",
  "move-core-types",
  "ol",
  "ol-keys",

--- a/ol/genesis-tools/Cargo.toml
+++ b/ol/genesis-tools/Cargo.toml
@@ -25,6 +25,7 @@ gumdrop = "0.8.0"
 ol = { path = "../cli/"}
 ol-keys = { path = "../keys/", version = "0.1.0" }
 ol-types = { path = "../types/" }
+language-e2e-tests = { path = "../../diem-move/e2e-tests", version="0.1.0"}
 #diem-network-address = { path = "../../network/network-address", version = "0.1.0" }
 
 [dev-dependencies]

--- a/ol/genesis-tools/src/exec_migration.rs
+++ b/ol/genesis-tools/src/exec_migration.rs
@@ -1,3 +1,4 @@
+
 //! Using the e2e test helpers we create a MoveVm session from fake data to be able to apply migrations
 //! from Move system contracts. i.e. we don't craft the writesets
 //! manually in rust, instead we execute functions in a Move session.
@@ -6,9 +7,11 @@ use diem_types::{write_set::WriteSet, account_config};
 use language_e2e_tests::executor::FakeExecutor;
 use move_core_types::value::{MoveValue, serialize_values};
 
-fn create_session(ws: &WriteSet) {
-    // let move_vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
-    // let fake_store = FakeDataStore::default()
+use crate::recover::LegacyRecovery;
+
+/// creates an executor vm session to create writesets
+pub fn create_session(ws: &WriteSet, _rec: LegacyRecovery) {
+
     let mut executor = FakeExecutor::from_genesis(ws);
     let output = executor.try_exec(
         "Diem",
@@ -21,3 +24,4 @@ fn create_session(ws: &WriteSet) {
 
     assert_eq!(output.unwrap_err().move_abort_code(), None);
 }
+

--- a/ol/genesis-tools/src/lib.rs
+++ b/ol/genesis-tools/src/lib.rs
@@ -15,3 +15,4 @@ pub mod process_snapshot;
 pub mod read_snapshot;
 pub mod recover;
 pub mod swarm_genesis;
+pub mod session;

--- a/ol/genesis-tools/src/lib.rs
+++ b/ol/genesis-tools/src/lib.rs
@@ -15,4 +15,4 @@ pub mod process_snapshot;
 pub mod read_snapshot;
 pub mod recover;
 pub mod swarm_genesis;
-pub mod session;
+pub mod exec_migration;

--- a/ol/genesis-tools/src/session.rs
+++ b/ol/genesis-tools/src/session.rs
@@ -1,0 +1,23 @@
+//! Using the e2e test helpers we create a MoveVm session from fake data to be able to apply migrations
+//! from Move system contracts. i.e. we don't craft the writesets
+//! manually in rust, instead we execute functions in a Move session.
+
+use diem_types::{write_set::WriteSet, account_config};
+use language_e2e_tests::executor::FakeExecutor;
+use move_core_types::value::{MoveValue, serialize_values};
+
+fn create_session(ws: &WriteSet) {
+    // let move_vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
+    // let fake_store = FakeDataStore::default()
+    let mut executor = FakeExecutor::from_genesis(ws);
+    let output = executor.try_exec(
+        "Diem",
+        "initialize",
+        vec![],
+        serialize_values(&vec![
+            MoveValue::Signer(account_config::diem_root_address()),
+        ]),
+    );
+
+    assert_eq!(output.unwrap_err().move_abort_code(), None);
+}

--- a/ol/genesis-tools/tests/fake_executor_test.rs
+++ b/ol/genesis-tools/tests/fake_executor_test.rs
@@ -1,0 +1,41 @@
+//! Using the e2e test helpers we create a MoveVm session from fake data to be able to apply migrations
+//! from Move system contracts. i.e. we don't craft the writesets
+//! manually in rust, instead we execute functions in a Move session.
+
+#[cfg(test)]
+use diem_types::account_config;
+use diem_types::write_set::WriteSetMut;
+use language_e2e_tests::executor::FakeExecutor;
+use move_core_types::value::{MoveValue, serialize_values};
+
+#[test]
+fn sanity_Check() {
+    let mut executor = FakeExecutor::from_fresh_genesis();    
+    let output = executor.try_exec(
+        "Debug",
+        "print_stack_trace",
+        vec![],
+        serialize_values(&vec![]),
+    );
+
+
+    assert_eq!(output.unwrap_err().move_abort_code(), None);
+}
+
+
+#[test]
+fn test_executor_migration() {
+    let ws = WriteSetMut::new(vec![]).freeze().unwrap();
+
+    let mut executor = FakeExecutor::from_genesis(&ws);
+    
+    let output = executor.try_exec(
+        "Debug",
+        "print_stack_trace",
+        vec![],
+        serialize_values(&vec![]),
+    );
+
+
+    assert_eq!(output.unwrap_err().move_abort_code(), None);
+}


### PR DESCRIPTION
The chain fork state migration pattern is currently hand crafting writesets. This can lead to bad state, and doesn't enforce any conditions. The best practice is to start an Executor instance, and call into certain functions, and then preserve the Writesets from those operations. Then we can add those Writesets to a clean genesis (the minimal bootstapping transactions e.g. validator set election).

- [ ] Create module to start a FakeExecutor instance that calls arbitrary functions, and returns writesets
- [ ] Merge a baseline genesis transactions (i.e. its writesets) to the migration writesets
- [ ] Replace previous migration scripts to new pattern
  - [ ] validator settings (perhaps it's ok since it uses genesis tx tools?)
  - [ ] account balance
  - [ ] TowerState
  - [ ] Autopay
  - [ ] Receipts
  - [ ] Community Wallets (note: split Donor Directed, and Community Wallet)
  - [ ] Ancestry
  - [ ] Fullnode Subsidy (rename to Oracle Subsidy)
  - [ ] Burn
  - [ ] Slow Wallet & unlocked balance (note: check unlocking logic)
 - [ ] New structs
   - [ ] Infra escrow pledges
   - [ ] Founder ID (bloom filter)
   - [ ] Coin Split
 - [ ] Not migrating:
   - [ ] Vouches
   - [ ] MakeWhole
- [ ] Make new tests infra confirm genesis for all items (from https://github.com/0LNetworkCommunity/libra/pull/1226)